### PR TITLE
Understand add member and authority system

### DIFF
--- a/room-grub/src/app/[room_id]/admin/_components/MembersList.jsx
+++ b/room-grub/src/app/[room_id]/admin/_components/MembersList.jsx
@@ -1,14 +1,46 @@
 'use client';
 
-import { Card, CardContent, Typography, Box, Stack, Chip, Table } from '@mui/joy';
+import { Card, CardContent, Typography, Box, Stack, Chip, Table, Select, Option, Button } from '@mui/joy';
 import { useRouter, useParams } from 'next/navigation';
+import { useState } from 'react';
+import { updateMemberRole } from '../../members/actions';
 
 export default function MembersList({ memberStats }) {
     const router = useRouter();
     const params = useParams();
+    const [updating, setUpdating] = useState({});
 
     const formatCurrency = (amount) => {
         return `₹${parseFloat(amount).toFixed(2)}`;
+    };
+
+    const handleRoleChange = async (memberEmail, currentRole) => {
+        const newRole = currentRole === 'Admin' ? 'Member' : 'Admin';
+        const confirmMessage = currentRole === 'Admin'
+            ? `Are you sure you want to demote ${memberEmail} to Member?`
+            : `Are you sure you want to promote ${memberEmail} to Admin?`;
+
+        if (!confirm(confirmMessage)) {
+            return;
+        }
+
+        setUpdating({ ...updating, [memberEmail]: true });
+
+        try {
+            const result = await updateMemberRole(params.room_id, memberEmail, newRole);
+
+            if (result.success) {
+                alert(result.message);
+                // Refresh the page to show updated data
+                router.refresh();
+            } else {
+                alert(`Error: ${result.error}`);
+            }
+        } catch (error) {
+            alert(`Failed to update role: ${error.message}`);
+        } finally {
+            setUpdating({ ...updating, [memberEmail]: false });
+        }
     };
 
     return (
@@ -43,19 +75,43 @@ export default function MembersList({ memberStats }) {
                                     }}
                                     onClick={() => router.push(`/${params.room_id}/members/${stat.member.id}`)}
                                 >
-                                    <Box>
-                                        <Typography level="title-sm" sx={{ fontSize: '1rem' }}>
-                                            {stat.member.name}
-                                        </Typography>
+                                    <Box sx={{ flex: 1 }}>
+                                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+                                            <Typography level="title-sm" sx={{ fontSize: '1rem' }}>
+                                                {stat.member.name}
+                                            </Typography>
+                                            <Chip
+                                                size="sm"
+                                                color={stat.member.role === 'Admin' ? 'primary' : 'neutral'}
+                                                variant="soft"
+                                            >
+                                                {stat.member.role}
+                                            </Chip>
+                                        </Box>
                                         <Typography level="body-xs" sx={{ color: 'text.secondary', fontSize: '0.85rem' }}>
                                             {stat.member.email}
                                         </Typography>
+                                        <Box sx={{ mt: 1 }}>
+                                            <Button
+                                                size="sm"
+                                                variant="outlined"
+                                                color={stat.member.role === 'Admin' ? 'danger' : 'success'}
+                                                onClick={(e) => {
+                                                    e.stopPropagation();
+                                                    handleRoleChange(stat.member.email, stat.member.role);
+                                                }}
+                                                loading={updating[stat.member.email]}
+                                                disabled={updating[stat.member.email]}
+                                            >
+                                                {stat.member.role === 'Admin' ? 'Demote to Member' : 'Promote to Admin'}
+                                            </Button>
+                                        </Box>
                                     </Box>
                                     <Box sx={{ textAlign: 'right' }}>
-                                        <Typography sx={{ 
-                                            color: stat.pendingAmount > 0 ? 'danger.500' : 'success.500', 
-                                            fontWeight: 'bold', 
-                                            fontSize: '1.1rem' 
+                                        <Typography sx={{
+                                            color: stat.pendingAmount > 0 ? 'danger.500' : 'success.500',
+                                            fontWeight: 'bold',
+                                            fontSize: '1.1rem'
                                         }}>
                                             {formatCurrency(stat.pendingAmount)}
                                         </Typography>
@@ -78,6 +134,7 @@ export default function MembersList({ memberStats }) {
                             <thead>
                                 <tr>
                                     <th>Member</th>
+                                    <th>Role</th>
                                     <th>Total Purchases</th>
                                     <th>Amount Received</th>
                                     <th>Monthly Contributions</th>
@@ -103,6 +160,15 @@ export default function MembersList({ memberStats }) {
                                                     {stat.member.email}
                                                 </Typography>
                                             </Box>
+                                        </td>
+                                        <td>
+                                            <Chip
+                                                size="sm"
+                                                color={stat.member.role === 'Admin' ? 'primary' : 'neutral'}
+                                                variant="soft"
+                                            >
+                                                {stat.member.role}
+                                            </Chip>
                                         </td>
                                         <td>
                                             <Typography sx={{ color: 'success.500', fontSize: { xs: '0.95rem', sm: '1rem' } }}>
@@ -141,7 +207,19 @@ export default function MembersList({ memberStats }) {
                                             </Chip>
                                         </td>
                                         <td>
-                                            {/* No View Details button, row is clickable */}
+                                            <Button
+                                                size="sm"
+                                                variant="outlined"
+                                                color={stat.member.role === 'Admin' ? 'danger' : 'success'}
+                                                onClick={(e) => {
+                                                    e.stopPropagation();
+                                                    handleRoleChange(stat.member.email, stat.member.role);
+                                                }}
+                                                loading={updating[stat.member.email]}
+                                                disabled={updating[stat.member.email]}
+                                            >
+                                                {stat.member.role === 'Admin' ? 'Demote' : 'Promote'}
+                                            </Button>
                                         </td>
                                     </tr>
                                 ))}

--- a/room-grub/src/app/[room_id]/admin/_components/MembersList.jsx
+++ b/room-grub/src/app/[room_id]/admin/_components/MembersList.jsx
@@ -1,46 +1,14 @@
 'use client';
 
-import { Card, CardContent, Typography, Box, Stack, Chip, Table, Select, Option, Button } from '@mui/joy';
+import { Card, CardContent, Typography, Box, Stack, Chip, Table } from '@mui/joy';
 import { useRouter, useParams } from 'next/navigation';
-import { useState } from 'react';
-import { updateMemberRole } from '../../members/actions';
 
 export default function MembersList({ memberStats }) {
     const router = useRouter();
     const params = useParams();
-    const [updating, setUpdating] = useState({});
 
     const formatCurrency = (amount) => {
         return `₹${parseFloat(amount).toFixed(2)}`;
-    };
-
-    const handleRoleChange = async (memberEmail, currentRole) => {
-        const newRole = currentRole === 'Admin' ? 'Member' : 'Admin';
-        const confirmMessage = currentRole === 'Admin'
-            ? `Are you sure you want to demote ${memberEmail} to Member?`
-            : `Are you sure you want to promote ${memberEmail} to Admin?`;
-
-        if (!confirm(confirmMessage)) {
-            return;
-        }
-
-        setUpdating({ ...updating, [memberEmail]: true });
-
-        try {
-            const result = await updateMemberRole(params.room_id, memberEmail, newRole);
-
-            if (result.success) {
-                alert(result.message);
-                // Refresh the page to show updated data
-                router.refresh();
-            } else {
-                alert(`Error: ${result.error}`);
-            }
-        } catch (error) {
-            alert(`Failed to update role: ${error.message}`);
-        } finally {
-            setUpdating({ ...updating, [memberEmail]: false });
-        }
     };
 
     return (
@@ -75,37 +43,13 @@ export default function MembersList({ memberStats }) {
                                     }}
                                     onClick={() => router.push(`/${params.room_id}/members/${stat.member.id}`)}
                                 >
-                                    <Box sx={{ flex: 1 }}>
-                                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
-                                            <Typography level="title-sm" sx={{ fontSize: '1rem' }}>
-                                                {stat.member.name}
-                                            </Typography>
-                                            <Chip
-                                                size="sm"
-                                                color={stat.member.role === 'Admin' ? 'primary' : 'neutral'}
-                                                variant="soft"
-                                            >
-                                                {stat.member.role}
-                                            </Chip>
-                                        </Box>
+                                    <Box>
+                                        <Typography level="title-sm" sx={{ fontSize: '1rem' }}>
+                                            {stat.member.name}
+                                        </Typography>
                                         <Typography level="body-xs" sx={{ color: 'text.secondary', fontSize: '0.85rem' }}>
                                             {stat.member.email}
                                         </Typography>
-                                        <Box sx={{ mt: 1 }}>
-                                            <Button
-                                                size="sm"
-                                                variant="outlined"
-                                                color={stat.member.role === 'Admin' ? 'danger' : 'success'}
-                                                onClick={(e) => {
-                                                    e.stopPropagation();
-                                                    handleRoleChange(stat.member.email, stat.member.role);
-                                                }}
-                                                loading={updating[stat.member.email]}
-                                                disabled={updating[stat.member.email]}
-                                            >
-                                                {stat.member.role === 'Admin' ? 'Demote to Member' : 'Promote to Admin'}
-                                            </Button>
-                                        </Box>
                                     </Box>
                                     <Box sx={{ textAlign: 'right' }}>
                                         <Typography sx={{
@@ -134,7 +78,6 @@ export default function MembersList({ memberStats }) {
                             <thead>
                                 <tr>
                                     <th>Member</th>
-                                    <th>Role</th>
                                     <th>Total Purchases</th>
                                     <th>Amount Received</th>
                                     <th>Monthly Contributions</th>
@@ -160,15 +103,6 @@ export default function MembersList({ memberStats }) {
                                                     {stat.member.email}
                                                 </Typography>
                                             </Box>
-                                        </td>
-                                        <td>
-                                            <Chip
-                                                size="sm"
-                                                color={stat.member.role === 'Admin' ? 'primary' : 'neutral'}
-                                                variant="soft"
-                                            >
-                                                {stat.member.role}
-                                            </Chip>
                                         </td>
                                         <td>
                                             <Typography sx={{ color: 'success.500', fontSize: { xs: '0.95rem', sm: '1rem' } }}>
@@ -207,19 +141,7 @@ export default function MembersList({ memberStats }) {
                                             </Chip>
                                         </td>
                                         <td>
-                                            <Button
-                                                size="sm"
-                                                variant="outlined"
-                                                color={stat.member.role === 'Admin' ? 'danger' : 'success'}
-                                                onClick={(e) => {
-                                                    e.stopPropagation();
-                                                    handleRoleChange(stat.member.email, stat.member.role);
-                                                }}
-                                                loading={updating[stat.member.email]}
-                                                disabled={updating[stat.member.email]}
-                                            >
-                                                {stat.member.role === 'Admin' ? 'Demote' : 'Promote'}
-                                            </Button>
+                                            {/* No View Details button, row is clickable */}
                                         </td>
                                     </tr>
                                 ))}

--- a/room-grub/src/app/[room_id]/members/_components/ListMembers.jsx
+++ b/room-grub/src/app/[room_id]/members/_components/ListMembers.jsx
@@ -1,13 +1,64 @@
 'use client'
-import React from 'react';
-import { Box, Typography, Button, Card, CardContent, Stack } from '@mui/joy';
+import React, { useState } from 'react';
+import { Box, Typography, Button, Card, CardContent, Stack, Chip, IconButton, Modal, ModalDialog, ModalClose } from '@mui/joy';
 import { useRouter } from 'next/navigation';
+import useUserRole from '@/hooks/useUserRole';
+import { updateMemberRole } from '../actions';
+import EditIcon from '@mui/icons-material/Edit';
 
 export default function ListMembers({ members, roomId }) {
     const router = useRouter();
+    const { role, loadings } = useUserRole();
+    const [updating, setUpdating] = useState({});
+    const [editModal, setEditModal] = useState({ open: false, member: null });
+
     console.log(members)
+
     const handleAddFriend = () => {
         router.push(`/${roomId}/members/add`);
+    };
+
+    const handleOpenEditModal = (e, member) => {
+        e.stopPropagation();
+        setEditModal({ open: true, member });
+    };
+
+    const handleCloseEditModal = () => {
+        setEditModal({ open: false, member: null });
+    };
+
+    const handleRoleChange = async (newRole) => {
+        if (!editModal.member) return;
+
+        const memberEmail = editModal.member.email;
+        const currentRole = editModal.member.role;
+
+        const confirmMessage = newRole === 'Admin'
+            ? `Are you sure you want to promote ${editModal.member.name} to Admin?`
+            : `Are you sure you want to demote ${editModal.member.name} to Member?`;
+
+        if (!confirm(confirmMessage)) {
+            return;
+        }
+
+        setUpdating({ ...updating, [memberEmail]: true });
+
+        try {
+            const result = await updateMemberRole(roomId, memberEmail, newRole);
+
+            if (result.success) {
+                alert(result.message);
+                handleCloseEditModal();
+                // Refresh the page to show updated data
+                router.refresh();
+            } else {
+                alert(`Error: ${result.error}`);
+            }
+        } catch (error) {
+            alert(`Failed to update role: ${error.message}`);
+        } finally {
+            setUpdating({ ...updating, [memberEmail]: false });
+        }
     };
 
     return (
@@ -63,28 +114,50 @@ export default function ListMembers({ members, roomId }) {
                             onClick={() => router.push(`/${roomId}/members/${member.id}`)}
                         >
                             <CardContent>
-                                <Stack direction="row" spacing={2} alignItems="center">
-                                    <Box
-                                        component="img"
-                                        src={member.profile || '/default-profile.png'}
-                                        alt={member.name}
-                                        sx={{
-                                            width: 48,
-                                            height: 48,
-                                            borderRadius: '50%',
-                                            objectFit: 'cover',
-                                            bgcolor: 'background.level2',
-                                            border: '1px solid #eee',
-                                        }}
-                                        onError={e => {
-                                            e.target.onerror = null;
-                                            e.target.src = '/default-profile.png';
-                                        }}
-                                    />
-                                    <Box>
-                                        <Typography level="title-md">{member.name}</Typography>
-                                        <Typography level="body-sm">{member.email}</Typography>
-                                    </Box>
+                                <Stack direction="row" spacing={2} alignItems="center" justifyContent="space-between">
+                                    <Stack direction="row" spacing={2} alignItems="center" sx={{ flex: 1 }}>
+                                        <Box
+                                            component="img"
+                                            src={member.profile || '/default-profile.png'}
+                                            alt={member.name}
+                                            sx={{
+                                                width: 48,
+                                                height: 48,
+                                                borderRadius: '50%',
+                                                objectFit: 'cover',
+                                                bgcolor: 'background.level2',
+                                                border: '1px solid #eee',
+                                            }}
+                                            onError={e => {
+                                                e.target.onerror = null;
+                                                e.target.src = '/default-profile.png';
+                                            }}
+                                        />
+                                        <Box sx={{ flex: 1 }}>
+                                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+                                                <Typography level="title-md">{member.name}</Typography>
+                                                <Chip
+                                                    size="sm"
+                                                    color={member.role === 'Admin' ? 'primary' : 'neutral'}
+                                                    variant="soft"
+                                                >
+                                                    {member.role}
+                                                </Chip>
+                                            </Box>
+                                            <Typography level="body-sm">{member.email}</Typography>
+                                        </Box>
+                                    </Stack>
+                                    {!loadings && role === 'Admin' && (
+                                        <IconButton
+                                            size="sm"
+                                            variant="plain"
+                                            color="neutral"
+                                            onClick={(e) => handleOpenEditModal(e, member)}
+                                            sx={{ ml: 1 }}
+                                        >
+                                            <EditIcon />
+                                        </IconButton>
+                                    )}
                                 </Stack>
                             </CardContent>
                         </Card>
@@ -104,6 +177,63 @@ export default function ListMembers({ members, roomId }) {
             >
                 Add Friend
             </Button>
+
+            {/* Edit Role Modal */}
+            <Modal open={editModal.open} onClose={handleCloseEditModal}>
+                <ModalDialog sx={{ minWidth: 400 }}>
+                    <ModalClose />
+                    <Typography level="h4" sx={{ mb: 2 }}>
+                        Edit Member Role
+                    </Typography>
+                    {editModal.member && (
+                        <Box>
+                            <Box sx={{ mb: 3 }}>
+                                <Typography level="body-sm" sx={{ mb: 0.5 }}>
+                                    Member: <strong>{editModal.member.name}</strong>
+                                </Typography>
+                                <Typography level="body-sm" sx={{ mb: 1 }}>
+                                    Email: {editModal.member.email}
+                                </Typography>
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                    <Typography level="body-sm">
+                                        Current Role:
+                                    </Typography>
+                                    <Chip
+                                        size="sm"
+                                        color={editModal.member.role === 'Admin' ? 'primary' : 'neutral'}
+                                        variant="soft"
+                                    >
+                                        {editModal.member.role}
+                                    </Chip>
+                                </Box>
+                            </Box>
+                            <Typography level="body-sm" sx={{ mb: 2 }}>
+                                Change role to:
+                            </Typography>
+                            <Stack spacing={2}>
+                                <Button
+                                    variant="solid"
+                                    color="success"
+                                    onClick={() => handleRoleChange('Admin')}
+                                    disabled={editModal.member.role === 'Admin' || updating[editModal.member.email]}
+                                    loading={updating[editModal.member.email]}
+                                >
+                                    Promote to Admin
+                                </Button>
+                                <Button
+                                    variant="solid"
+                                    color="danger"
+                                    onClick={() => handleRoleChange('Member')}
+                                    disabled={editModal.member.role === 'Member' || updating[editModal.member.email]}
+                                    loading={updating[editModal.member.email]}
+                                >
+                                    Demote to Member
+                                </Button>
+                            </Stack>
+                        </Box>
+                    )}
+                </ModalDialog>
+            </Modal>
         </Box>
     );
 }

--- a/room-grub/src/app/[room_id]/members/actions.js
+++ b/room-grub/src/app/[room_id]/members/actions.js
@@ -1,0 +1,87 @@
+'use server';
+
+import { createClient } from '@/utils/supabase/server';
+import { revalidatePath } from 'next/cache';
+
+export async function updateMemberRole(roomId, memberEmail, newRole) {
+    try {
+        const supabase = await createClient();
+
+        // SECURITY CHECK 1: Verify user is authenticated
+        const { data: { user }, error: authError } = await supabase.auth.getUser();
+        if (authError || !user) {
+            return { success: false, error: 'Unauthorized: User not authenticated' };
+        }
+
+        // SECURITY CHECK 2: Verify current user is admin
+        const { data: currentUser } = await supabase
+            .from('Users')
+            .select('role, room, email')
+            .eq('email', user.email)
+            .single();
+
+        if (currentUser?.role !== 'Admin') {
+            return { success: false, error: 'Unauthorized: Only admins can change member roles' };
+        }
+
+        // SECURITY CHECK 3: Verify current user belongs to this room
+        if (currentUser?.room !== parseInt(roomId)) {
+            return { success: false, error: 'Unauthorized: User not a member of this room' };
+        }
+
+        // SECURITY CHECK 4: Prevent self-demotion
+        if (currentUser.email === memberEmail && newRole !== 'Admin') {
+            return { success: false, error: 'Cannot demote yourself from admin role' };
+        }
+
+        // VALIDATION 1: Verify new role is valid
+        if (newRole !== 'Admin' && newRole !== 'Member') {
+            return { success: false, error: 'Invalid role. Must be "Admin" or "Member"' };
+        }
+
+        // VALIDATION 2: Verify target member exists and belongs to the same room
+        const { data: targetMember, error: memberError } = await supabase
+            .from('Users')
+            .select('email, room, role')
+            .eq('email', memberEmail)
+            .single();
+
+        if (memberError || !targetMember) {
+            return { success: false, error: 'Member not found' };
+        }
+
+        if (targetMember.room !== parseInt(roomId)) {
+            return { success: false, error: 'Member does not belong to this room' };
+        }
+
+        // Check if role is already the same
+        if (targetMember.role === newRole) {
+            return { success: false, error: `Member is already a ${newRole}` };
+        }
+
+        // Update the member's role
+        const { error: updateError } = await supabase
+            .from('Users')
+            .update({ role: newRole })
+            .eq('email', memberEmail)
+            .eq('room', roomId);
+
+        if (updateError) {
+            console.error('Error updating member role:', updateError);
+            throw new Error('Failed to update member role');
+        }
+
+        // Revalidate relevant pages
+        revalidatePath(`/${roomId}/members`);
+        revalidatePath(`/${roomId}/admin`);
+
+        return {
+            success: true,
+            message: `Successfully updated ${memberEmail} to ${newRole}`
+        };
+
+    } catch (error) {
+        console.error('Update member role error:', error);
+        return { success: false, error: error.message };
+    }
+}


### PR DESCRIPTION
Admins can now promote members to admin or demote admins to members through the admin dashboard. Includes server-side security checks to prevent unauthorized role changes and self-demotion.