### PR TITLE
feat: instant skeleton loading on page navigation

### DIFF
--- a/src/app/[room_id]/expenses/loading.jsx
+++ b/src/app/[room_id]/expenses/loading.jsx
@@ -1,0 +1,30 @@
+export default function ExpensesLoading() {
+  return (
+    <div className="animate-pulse">
+      <div className="px-4 pt-4 pb-2 flex gap-2">
+        <div className="h-8 bg-gray-200 rounded-full w-24" />
+        <div className="h-8 bg-gray-200 rounded-full w-24" />
+      </div>
+      <div className="divide-y divide-gray-100">
+        {[...Array(8)].map((_, i) => (
+          <div key={i} className="flex items-start gap-3 p-4">
+            <div className="relative flex-shrink-0">
+              <div className="w-11 h-11 rounded-full bg-gray-200" />
+              <div className="absolute -bottom-0.5 -right-0.5 w-4 h-4 rounded-full bg-gray-300" />
+            </div>
+            <div className="flex-1">
+              <div className="flex justify-between mb-1">
+                <div className="h-4 bg-gray-200 rounded w-28" />
+                <div className="h-4 bg-gray-200 rounded w-14" />
+              </div>
+              <div className="flex justify-between">
+                <div className="h-3 bg-gray-200 rounded w-20" />
+                <div className="h-3 bg-gray-200 rounded w-12" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/[room_id]/expenses/page.jsx
+++ b/src/app/[room_id]/expenses/page.jsx
@@ -1,12 +1,8 @@
 import ExpenseHistory from './_components/ExpenseHistory';
-import { LoginRequired } from '@/policies/LoginRequired';
-import { validRoom } from '@/policies/validRoom';
 import { createClient } from '@/utils/supabase/client';
 import { fetchPaginatedExpenses } from './actions';
 
 export default async function ExpensesPage({ params }) {
-    const user = await LoginRequired();
-    await validRoom({ params });
     const param = await params;
     const supabase = createClient();
 

--- a/src/app/[room_id]/layout.js
+++ b/src/app/[room_id]/layout.js
@@ -1,5 +1,9 @@
 import NavBarContainer from '@/components/NavBarContainer';
+import { LoginRequired } from '@/policies/LoginRequired';
+import { validRoom } from '@/policies/validRoom';
 
-export default function RoomLayout({ children }) {
+export default async function RoomLayout({ children, params }) {
+  await LoginRequired();
+  await validRoom({ params });
   return <NavBarContainer>{children}</NavBarContainer>;
 }

--- a/src/app/[room_id]/loading.jsx
+++ b/src/app/[room_id]/loading.jsx
@@ -1,0 +1,29 @@
+export default function HomeLoading() {
+  return (
+    <div className="px-4 py-2 animate-pulse">
+      <div className="h-7 bg-gray-200 rounded w-1/3 mb-6" />
+      <div className="rounded-xl border border-gray-100 bg-white p-4 mb-6">
+        <div className="h-5 bg-gray-200 rounded w-1/4 mb-4" />
+        <div className="grid grid-cols-2 gap-3">
+          <div className="rounded-xl bg-gray-100 p-4 h-16" />
+          <div className="rounded-xl bg-gray-100 p-4 h-16" />
+        </div>
+      </div>
+      <div className="h-5 bg-gray-200 rounded w-1/3 mb-4" />
+      <div className="flex flex-col gap-3">
+        {[...Array(3)].map((_, i) => (
+          <div key={i} className="flex items-center justify-between border border-gray-100 rounded-xl p-3 bg-white">
+            <div className="flex items-center gap-3">
+              <div className="w-12 h-12 rounded-full bg-gray-200 flex-shrink-0" />
+              <div>
+                <div className="h-4 bg-gray-200 rounded w-24 mb-2" />
+                <div className="h-3 bg-gray-200 rounded w-16" />
+              </div>
+            </div>
+            <div className="h-6 bg-gray-200 rounded w-16" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/[room_id]/members/loading.jsx
+++ b/src/app/[room_id]/members/loading.jsx
@@ -1,0 +1,24 @@
+export default function MembersLoading() {
+  return (
+    <div className="p-4 sm:p-8 bg-[#faf5ff] min-h-screen animate-pulse">
+      <div className="h-7 bg-gray-200 rounded w-40 mx-auto sm:mx-0 mb-6" />
+      <div className="flex flex-col sm:flex-row sm:flex-wrap gap-4 mb-6">
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="w-full sm:w-60 bg-white rounded-xl shadow-sm p-4">
+            <div className="flex items-center gap-3">
+              <div className="w-12 h-12 rounded-full bg-gray-200 flex-shrink-0" />
+              <div className="flex-1">
+                <div className="flex items-center gap-2 mb-1">
+                  <div className="h-4 bg-gray-200 rounded w-24" />
+                  <div className="h-4 bg-gray-200 rounded w-12" />
+                </div>
+                <div className="h-3 bg-gray-200 rounded w-32" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="h-10 bg-gray-200 rounded-lg w-full sm:w-32" />
+    </div>
+  );
+}

--- a/src/app/[room_id]/members/page.jsx
+++ b/src/app/[room_id]/members/page.jsx
@@ -1,16 +1,12 @@
 'use server'
 import { createClient } from '@/utils/supabase/server';
 import ListMembers from './_components/ListMembers';
-import { validRoom } from '@/policies/validRoom';
-import { LoginRequired } from '@/policies/LoginRequired';
+import { auth } from '@/auth';
 
 export default async function MembersPage({ params }) {
-    const session = await LoginRequired();
-    await validRoom({ params });
+    const session = await auth();
     const supabase = await createClient();
-    console.log("param is", params);
     const p = await params;
-    console.log("params is", p);
     const { data: members, error } = await supabase
         .from("Users")
         .select("*")

--- a/src/app/[room_id]/page.jsx
+++ b/src/app/[room_id]/page.jsx
@@ -1,5 +1,4 @@
-import { LoginRequired } from '@/policies/LoginRequired';
-import { validRoom } from '@/policies/validRoom';
+import { auth } from '@/auth';
 import { fetchRoomDashboard } from './homeActions';
 import WelCome from './_components/WelCome';
 import LazyNotificationPrompt from './_components/LazyNotificationPrompt';
@@ -7,8 +6,7 @@ import HomeDashboard from './_components/HomeDashboard';
 import Box from '@mui/joy/Box';
 
 export default async function Page({ params }) {
-  const session = await LoginRequired();
-  await validRoom({ params });
+  const session = await auth();
 
   const { room_id } = await params;
   const firstName = session.user.user_metadata?.full_name?.split(' ')[0] || 'there';

--- a/src/app/[room_id]/settings/loading.jsx
+++ b/src/app/[room_id]/settings/loading.jsx
@@ -1,0 +1,25 @@
+export default function SettingsLoading() {
+  return (
+    <div className="p-6 bg-[#f8f9fa] min-h-screen animate-pulse">
+      <div className="h-8 bg-gray-200 rounded w-40 mx-auto mb-8" />
+      <div className="max-w-[800px] mx-auto flex flex-col gap-6">
+        <div className="rounded-xl border border-gray-200 bg-white p-5">
+          <div className="h-5 bg-gray-200 rounded w-40 mb-3" />
+          <div className="h-10 bg-gray-200 rounded" />
+        </div>
+        <div className="rounded-xl border border-gray-200 bg-white p-5">
+          <div className="h-5 bg-gray-200 rounded w-36 mb-3" />
+          <div className="h-4 bg-gray-200 rounded w-full mb-2" />
+          <div className="h-4 bg-gray-200 rounded w-3/4 mb-4" />
+          <div className="h-10 bg-gray-200 rounded" />
+        </div>
+        <div className="rounded-lg border border-red-200 p-5">
+          <div className="h-5 bg-gray-200 rounded w-28 mb-2" />
+          <div className="h-4 bg-gray-200 rounded w-full mb-2" />
+          <div className="h-4 bg-gray-200 rounded w-2/3 mb-4" />
+          <div className="h-9 bg-gray-200 rounded w-28" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[room_id]/settings/page.jsx
+++ b/src/app/[room_id]/settings/page.jsx
@@ -1,13 +1,9 @@
 'use server'
 import ActivityHistoryCard from './_components/ActivityHistoryCard'
-import {LoginRequired} from '@/policies/LoginRequired'
-import { validRoom } from '@/policies/validRoom';
 import SettingsLayout from './_components/SettingsLayout';
 import DangerZone from './_components/DangerZone';
 
 export default async function page({params}){
-  const userr = await LoginRequired();
-  await validRoom({params});
   const p = await params;
   return(
     <SettingsLayout>

--- a/src/app/[room_id]/splits/loading.jsx
+++ b/src/app/[room_id]/splits/loading.jsx
@@ -1,0 +1,30 @@
+export default function SplitsLoading() {
+  return (
+    <div className="p-4 md:p-8 bg-[#faf5ff] min-h-screen animate-pulse">
+      <div className="flex flex-wrap gap-3 mb-6">
+        <div className="h-8 bg-gray-200 rounded w-32" />
+        <div className="h-8 bg-gray-200 rounded w-32" />
+        <div className="h-8 bg-gray-200 rounded w-24" />
+      </div>
+      <div className="rounded-xl bg-white border border-gray-100 p-5 mb-6">
+        <div className="h-5 bg-gray-200 rounded w-1/3 mb-3" />
+        <div className="h-8 bg-gray-200 rounded w-1/4" />
+      </div>
+      <div className="flex flex-col gap-3 mb-6">
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="flex items-center justify-between bg-white rounded-xl border border-gray-100 p-4">
+            <div className="flex items-center gap-3">
+              <div className="w-10 h-10 rounded-full bg-gray-200 flex-shrink-0" />
+              <div>
+                <div className="h-4 bg-gray-200 rounded w-24 mb-1" />
+                <div className="h-3 bg-gray-200 rounded w-16" />
+              </div>
+            </div>
+            <div className="h-5 bg-gray-200 rounded w-16" />
+          </div>
+        ))}
+      </div>
+      <div className="h-10 bg-gray-200 rounded-lg w-32" />
+    </div>
+  );
+}

--- a/src/app/[room_id]/splits/page.jsx
+++ b/src/app/[room_id]/splits/page.jsx
@@ -1,22 +1,13 @@
 import dynamic from 'next/dynamic';
-import { LoginRequired } from '@/policies/LoginRequired';
-import { validRoom } from '@/policies/validRoom';
+import { auth, getUserRoom } from '@/auth';
 import { createClient } from '@/utils/supabase/server';
 
 // Lazy load the heavy splits dashboard
-const SplitsDashboard = dynamic(() => import('./_components/SplitsDashboard'), {
-  loading: () => (
-    <div className="p-4 animate-pulse">
-      <div className="h-8 bg-gray-200 rounded w-1/3 mb-4"></div>
-      <div className="h-48 bg-gray-200 rounded mb-4"></div>
-      <div className="h-32 bg-gray-200 rounded"></div>
-    </div>
-  )
-});
+const SplitsDashboard = dynamic(() => import('./_components/SplitsDashboard'));
 
 export default async function SplitsPage({ params }) {
-  await LoginRequired();
-  const userData = await validRoom({ params });
+  const session = await auth();
+  const { data: userData } = await getUserRoom(session.user.email);
 
   const supabase = await createClient();
   const roomId = (await params).room_id;
@@ -57,7 +48,7 @@ export default async function SplitsPage({ params }) {
       payments={paymentsResult.data || []}
       members={membersResult.data || []}
       roomId={roomId}
-      userRole={userData?.role}
+      userRole={userData?.role ?? null}
     />
   );
 }


### PR DESCRIPTION
## Summary
- Added `loading.jsx` files for Home, Expenses, Members, Settings, and Splits pages using Next.js App Router's built-in Suspense convention
- Moved `LoginRequired()` and `validRoom()` auth checks from each page into the shared `[room_id]/layout.js` — this was the root cause of the lag (auth checks were blocking skeleton streaming)
- Removed redundant dynamic import loading skeleton from splits page to avoid double-flash

## Why this fixes the lag
Previously, each page awaited auth checks before any content could stream, so the skeleton appeared late. Now auth is resolved in the layout (cached via `React.cache()`), and pages only block on their data fetches — which happen *after* the skeleton is already visible.

## Test plan
- [ ] Navigate between Home, Expenses, Members, Settings, Splits using the bottom nav — each page should instantly show a pulsing skeleton
- [ ] Verify on slow network (DevTools → Network → Slow 3G) that skeletons are visible during the fetch
- [ ] Confirm Splits page shows only one skeleton (no double flash)
- [ ] Verify auth still works: unauthenticated users are redirected to `/login`, wrong room redirects too

🤖 Generated with [Claude Code](https://claude.ai/claude-code)