### PR TITLE
feat: share splits summary as image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "async": "^3.2.6",
         "autoprefixer": "^10.4.20",
         "date-fns": "^4.1.0",
+        "html2canvas": "^1.4.1",
         "next": "15.4.10",
         "next-auth": "^4.24.10",
         "pg": "^8.13.3",
@@ -5139,6 +5140,14 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -5671,6 +5680,14 @@
       "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css.escape": {
@@ -6819,6 +6836,18 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/http_ece": {
       "version": "1.2.0",
@@ -11147,6 +11176,14 @@
         "node": "*"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -11493,6 +11530,14 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/uuid": {
       "version": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "async": "^3.2.6",
     "autoprefixer": "^10.4.20",
     "date-fns": "^4.1.0",
+    "html2canvas": "^1.4.1",
     "next": "15.4.10",
     "next-auth": "^4.24.10",
     "pg": "^8.13.3",

--- a/src/app/[room_id]/splits/_components/SplitCalculator.jsx
+++ b/src/app/[room_id]/splits/_components/SplitCalculator.jsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import {
     Box,
     Typography,
@@ -15,14 +15,18 @@ import {
     Calculate,
     CheckCircle,
     Payment,
-    Receipt
+    Receipt,
+    NearMe
 } from '@mui/icons-material';
 import { settleAllPending } from '../actions';
 import { useRouter } from 'next/navigation';
+import SplitsShareCard from './SplitsShareCard';
 
 export default function SplitCalculator({ expenses, payments, members, filters, roomId, userRole }) {
     const router = useRouter();
+    const shareRef = useRef(null);
     const [isSettling, setIsSettling] = useState(false);
+    const [isSharing, setIsSharing] = useState(false);
     const [error, setError] = useState('');
     const [success, setSuccess] = useState('');
 
@@ -147,6 +151,36 @@ export default function SplitCalculator({ expenses, payments, members, filters, 
             setError(err.message || 'Failed to process settlement');
         } finally {
             setIsSettling(false);
+        }
+    };
+
+    const handleShare = async () => {
+        if (!shareRef.current) return;
+        setIsSharing(true);
+        try {
+            const html2canvas = (await import('html2canvas')).default;
+            const canvas = await html2canvas(shareRef.current, { useCORS: true, backgroundColor: '#faf5ff' });
+            canvas.toBlob(async (blob) => {
+                const file = new File([blob], 'splits-summary.png', { type: 'image/png' });
+                if (navigator.canShare && navigator.canShare({ files: [file] })) {
+                    await navigator.share({
+                        files: [file],
+                        title: 'RoomGrub Splits',
+                        text: 'Check out our expense splits!',
+                    });
+                } else {
+                    const url = URL.createObjectURL(blob);
+                    const a = document.createElement('a');
+                    a.href = url;
+                    a.download = 'splits-summary.png';
+                    a.click();
+                    URL.revokeObjectURL(url);
+                }
+                setIsSharing(false);
+            }, 'image/png');
+        } catch (err) {
+            if (err.name !== 'AbortError') setError('Failed to share. Please try again.');
+            setIsSharing(false);
         }
     };
 
@@ -307,32 +341,64 @@ export default function SplitCalculator({ expenses, payments, members, filters, 
                 </Box>
             )}
 
-            {/* Settle All Button - Full Width at Bottom - Admin Only */}
-            {splitCalculation.pendingSettlements.length > 0 && userRole === 'Admin' && (
-                <Button
-                    fullWidth
-                    color="primary"
-                    size="lg"
-                    onClick={handleSettleAll}
-                    loading={isSettling}
-                    startDecorator={!isSettling && <Payment />}
-                    disabled={isSettling}
-                    sx={{
-                        py: 1.5,
-                        fontSize: '1rem',
-                        fontWeight: 600,
-                        borderRadius: 'md',
-                        textTransform: 'none',
-                        bgcolor: '#7e22ce',
-                        '&:hover': { bgcolor: '#6b21a8' },
-                    }}
-                >
-                    {isSettling
-                        ? 'Settling...'
-                        : `Settle All (${splitCalculation.pendingSettlements.length})`
-                    }
-                </Button>
+            {/* Action Buttons Row */}
+            {splitCalculation.pendingSettlements.length > 0 && (
+                <Box sx={{ display: 'flex', gap: 1.5 }}>
+                    {/* Share Icon Button */}
+                    <Button
+                        variant="outlined"
+                        color="primary"
+                        size="lg"
+                        onClick={handleShare}
+                        loading={isSharing}
+                        sx={{
+                            py: 1.5,
+                            px: 2,
+                            borderRadius: 'md',
+                            borderColor: '#7e22ce',
+                            color: '#7e22ce',
+                            flexShrink: 0,
+                            minWidth: 'unset',
+                            '&:hover': { bgcolor: '#f3e8ff' },
+                        }}
+                    >
+                        {!isSharing && (
+                            <NearMe sx={{ fontSize: 28 }} />
+                        )}
+                    </Button>
+
+                    {/* Settle All Button - Admin Only */}
+                    {userRole === 'Admin' && (
+                        <Button
+                            fullWidth
+                            color="primary"
+                            size="lg"
+                            onClick={handleSettleAll}
+                            loading={isSettling}
+                            startDecorator={!isSettling && <Payment />}
+                            disabled={isSettling}
+                            sx={{
+                                py: 1.5,
+                                fontSize: '1rem',
+                                fontWeight: 600,
+                                borderRadius: 'md',
+                                textTransform: 'none',
+                                bgcolor: '#7e22ce',
+                                '&:hover': { bgcolor: '#6b21a8' },
+                            }}
+                        >
+                            {isSettling ? 'Settling...' : `Settle All (${splitCalculation.pendingSettlements.length})`}
+                        </Button>
+                    )}
+                </Box>
             )}
+
+            {/* Hidden share snapshot — rendered off-screen for html2canvas capture */}
+            <SplitsShareCard
+                shareRef={shareRef}
+                splitCalculation={splitCalculation}
+                filters={filters}
+            />
         </Box>
     );
 }

--- a/src/app/[room_id]/splits/_components/SplitsShareCard.jsx
+++ b/src/app/[room_id]/splits/_components/SplitsShareCard.jsx
@@ -1,0 +1,137 @@
+'use client';
+
+import React from 'react';
+
+const formatAmount = (amount) =>
+    new Intl.NumberFormat('en-IN', {
+        style: 'currency',
+        currency: 'INR',
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+    }).format(Math.abs(amount));
+
+export default function SplitsShareCard({ shareRef, splitCalculation, roomName, filters }) {
+    const { totalPendingExpenses, equalShare, memberBalances } = splitCalculation;
+
+    const from = filters?.dateRange?.from;
+    const to = filters?.dateRange?.to;
+    const formatDate = (d) => new Date(d).toLocaleDateString('en-IN', { day: 'numeric', month: 'short', year: 'numeric' });
+    const dateLabel = from || to
+        ? from && to
+            ? `${formatDate(from)} – ${formatDate(to)}`
+            : from
+            ? `From ${formatDate(from)}`
+            : `Until ${formatDate(to)}`
+        : null;
+
+    return (
+        <div
+            ref={shareRef}
+            style={{
+                position: 'absolute',
+                left: '-9999px',
+                top: 0,
+                width: '380px',
+                background: '#faf5ff',
+                borderRadius: '16px',
+                padding: '24px',
+                fontFamily: "'Inter', 'Segoe UI', sans-serif",
+                color: '#1a1a2e',
+            }}
+        >
+            {/* Header */}
+            <div style={{ marginBottom: '20px', borderBottom: '2px solid #e9d5ff', paddingBottom: '16px' }}>
+                <div style={{ fontSize: '20px', fontWeight: 700, color: '#7e22ce', marginBottom: '4px' }}>
+                    🏠 {roomName || 'RoomGrub'}
+                </div>
+                <div style={{ fontSize: '13px', color: '#9333ea' }}>
+                    Expense Splits Summary
+                </div>
+                {dateLabel && (
+                    <div style={{
+                        marginTop: '6px',
+                        display: 'inline-block',
+                        fontSize: '12px',
+                        fontWeight: 600,
+                        color: '#6d28d9',
+                        background: '#ede9fe',
+                        borderRadius: '6px',
+                        padding: '3px 8px',
+                    }}>
+                        🗓 {dateLabel}
+                    </div>
+                )}
+            </div>
+
+            {/* Summary Row */}
+            <div style={{ display: 'flex', gap: '12px', marginBottom: '20px' }}>
+                <div style={{
+                    flex: 1, background: '#ede9fe', borderRadius: '12px',
+                    padding: '12px', textAlign: 'center'
+                }}>
+                    <div style={{ fontSize: '11px', color: '#6d28d9', fontWeight: 600, marginBottom: '4px' }}>
+                        TOTAL PENDING
+                    </div>
+                    <div style={{ fontSize: '20px', fontWeight: 700, color: '#4c1d95' }}>
+                        {formatAmount(totalPendingExpenses)}
+                    </div>
+                </div>
+                <div style={{
+                    flex: 1, background: '#d1fae5', borderRadius: '12px',
+                    padding: '12px', textAlign: 'center'
+                }}>
+                    <div style={{ fontSize: '11px', color: '#065f46', fontWeight: 600, marginBottom: '4px' }}>
+                        PER PERSON
+                    </div>
+                    <div style={{ fontSize: '20px', fontWeight: 700, color: '#064e3b' }}>
+                        {formatAmount(equalShare)}
+                    </div>
+                </div>
+            </div>
+
+            {/* Member Balances */}
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '10px', marginBottom: '20px' }}>
+                {memberBalances.map((mb) => {
+                    const isCredit = mb.status === 'credit';
+                    const isDebit = mb.status === 'debit';
+                    const bg = isCredit ? '#d1fae5' : isDebit ? '#fee2e2' : '#f3f4f6';
+                    const color = isCredit ? '#065f46' : isDebit ? '#991b1b' : '#374151';
+                    const label = isCredit ? '▲ gets back' : isDebit ? '▼ owes' : '✓ even';
+                    const initial = (mb.member.name || mb.member.email).charAt(0).toUpperCase();
+
+                    return (
+                        <div key={mb.member.email} style={{
+                            display: 'flex', alignItems: 'center', gap: '12px',
+                            background: bg, borderRadius: '10px', padding: '10px 12px'
+                        }}>
+                            <div style={{
+                                width: '36px', height: '36px', borderRadius: '50%',
+                                background: '#7e22ce', color: '#fff',
+                                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                                fontSize: '15px', fontWeight: 700, flexShrink: 0
+                            }}>
+                                {initial}
+                            </div>
+                            <div style={{ flex: 1 }}>
+                                <div style={{ fontSize: '14px', fontWeight: 600, color }}>
+                                    {mb.member.name || mb.member.email}
+                                </div>
+                                <div style={{ fontSize: '11px', color, opacity: 0.8 }}>
+                                    {label}
+                                </div>
+                            </div>
+                            <div style={{ fontSize: '16px', fontWeight: 700, color }}>
+                                {mb.status === 'even' ? '₹0' : formatAmount(mb.balance)}
+                            </div>
+                        </div>
+                    );
+                })}
+            </div>
+
+            {/* Footer */}
+            <div style={{ textAlign: 'center', fontSize: '11px', color: '#a78bfa' }}>
+                Shared via RoomGrub
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- Adds a share button (NearMe icon) on the splits page next to the Settle All button
- On click, captures the splits summary as a PNG using `html2canvas` and triggers the native Web Share API (WhatsApp, Telegram, etc.) — falls back to download on desktop
- Shared image includes member balances, total pending, per-person amount, and the active date filter range

## Test plan
- [ ] Open splits page on mobile → tap share icon → native share sheet opens with PNG attached
- [ ] Share to WhatsApp/Telegram and verify image is readable
- [ ] On desktop → clicking share downloads `splits-summary.png`
- [ ] Set a date filter → share → verify date range badge appears in the image
- [ ] No date filter → share → verify no date badge in image

🤖 Generated with [Claude Code](https://claude.com/claude-code)