### PR TITLE
refactor: activity history — pending expenses only with rich filter bar

### DIFF
--- a/src/app/[room_id]/settings/activities/_components/ActivityCard.jsx
+++ b/src/app/[room_id]/settings/activities/_components/ActivityCard.jsx
@@ -4,7 +4,6 @@ import { Box, Typography, IconButton, Chip, Sheet } from '@mui/joy';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
-import PaymentIcon from '@mui/icons-material/Payment';
 import { format } from 'date-fns';
 import EditActivityDialog from './EditActivityDialog';
 import DeleteConfirmDialog from './DeleteConfirmDialog';
@@ -13,23 +12,7 @@ export default function ActivityCard({ activity, isAdmin, roomId }) {
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
-  const isGrocery = activity.type === 'grocery';
-  const isPayment = activity.type === 'payment';
-
-  // Format date
-  const formattedDate = format(new Date(activity.createdAt), 'MMM dd, yyyy HH:mm');
-
-  // Determine color and icon based on activity type
-  const getActivityColor = () => {
-    if (isGrocery) return 'primary';
-    if (activity.paymentType === 'credit') return 'success';
-    return 'warning';
-  };
-
-  const getActivityIcon = () => {
-    if (isGrocery) return <ShoppingCartIcon />;
-    return <PaymentIcon />;
-  };
+  const formattedDate = format(new Date(activity.createdAt), 'MMM dd, yyyy');
 
   return (
     <>
@@ -49,35 +32,28 @@ export default function ActivityCard({ activity, isAdmin, roomId }) {
         }}
       >
         <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
-          {/* Left side - Activity info */}
           <Box sx={{ display: 'flex', gap: 2, flex: 1 }}>
-            {/* Icon */}
             <Box sx={{
               width: 48,
               height: 48,
               borderRadius: '50%',
-              bgcolor: `${getActivityColor()}.softBg`,
+              bgcolor: 'primary.softBg',
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              color: `${getActivityColor()}.solidColor`,
+              color: 'primary.solidColor',
               flexShrink: 0,
             }}>
-              {getActivityIcon()}
+              <ShoppingCartIcon />
             </Box>
 
-            {/* Details */}
             <Box sx={{ flex: 1 }}>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
                 <Typography level="title-md" sx={{ fontWeight: 600 }}>
-                  {isGrocery ? activity.description : activity.description}
+                  {activity.description}
                 </Typography>
-                <Chip
-                  size="sm"
-                  color={getActivityColor()}
-                  variant="soft"
-                >
-                  {isGrocery ? 'Grocery' : activity.paymentType === 'credit' ? 'Credit' : 'Debit'}
+                <Chip size="sm" color="warning" variant="soft">
+                  Pending
                 </Chip>
               </Box>
 
@@ -85,8 +61,8 @@ export default function ActivityCard({ activity, isAdmin, roomId }) {
                 By: {activity.user}
               </Typography>
 
-              <Typography level="title-lg" sx={{ fontWeight: 700, color: getActivityColor() + '.solidColor' }}>
-                ${parseFloat(activity.amount).toFixed(2)}
+              <Typography level="title-lg" sx={{ fontWeight: 700, color: 'primary.solidColor' }}>
+                ₹{parseFloat(activity.amount).toFixed(2)}
               </Typography>
 
               <Typography level="body-xs" sx={{ color: 'text.tertiary', mt: 1 }}>
@@ -95,7 +71,6 @@ export default function ActivityCard({ activity, isAdmin, roomId }) {
             </Box>
           </Box>
 
-          {/* Right side - Action buttons (admin only) */}
           {isAdmin && (
             <Box sx={{ display: 'flex', gap: 1, ml: 2 }}>
               <IconButton
@@ -119,7 +94,6 @@ export default function ActivityCard({ activity, isAdmin, roomId }) {
         </Box>
       </Sheet>
 
-      {/* Edit Dialog */}
       <EditActivityDialog
         open={editDialogOpen}
         onClose={() => setEditDialogOpen(false)}
@@ -127,7 +101,6 @@ export default function ActivityCard({ activity, isAdmin, roomId }) {
         roomId={roomId}
       />
 
-      {/* Delete Confirmation Dialog */}
       <DeleteConfirmDialog
         open={deleteDialogOpen}
         onClose={() => setDeleteDialogOpen(false)}

--- a/src/app/[room_id]/settings/activities/_components/ActivityFilters.jsx
+++ b/src/app/[room_id]/settings/activities/_components/ActivityFilters.jsx
@@ -1,45 +1,90 @@
 'use client'
 import React from 'react';
-import { Box, Typography, Sheet } from '@mui/joy';
-import FilterListIcon from '@mui/icons-material/FilterList';
+import { Box, Card, Select, Input, Option } from '@mui/joy';
 
-export default function ActivityFilters({ filterType, onFilterChange }) {
+export default function ActivityFilters({
+  userFilter,
+  setUserFilter,
+  textFilter,
+  setTextFilter,
+  dateRange,
+  setDateRange,
+  userMap,
+}) {
   return (
-    <Sheet
-      variant="outlined"
+    <Card
+      variant="soft"
       sx={{
-        padding: 2.5,
-        borderRadius: '12px',
-        bgcolor: 'background.surface',
-        border: '1px solid',
-        borderColor: 'neutral.outlinedBorder',
+        mb: 3,
+        borderRadius: 2,
+        boxShadow: 'none',
+        bgcolor: 'transparent',
+        p: 1,
+        overflowX: 'auto',
+        scrollbarWidth: 'none',
+        '&::-webkit-scrollbar': { display: 'none' },
       }}
     >
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-        <FilterListIcon sx={{ color: 'text.secondary' }} />
-        <Typography level="title-sm" sx={{ fontWeight: 600 }}>
-          Filter by:
-        </Typography>
-        <select
-          value={filterType}
-          onChange={(e) => onFilterChange(e.target.value)}
-          style={{
-            flex: 1,
-            maxWidth: '250px',
-            padding: '8px 12px',
-            fontSize: '0.95rem',
-            border: '1px solid #ccc',
-            borderRadius: '6px',
-            backgroundColor: 'white',
-            color: 'black',
-            cursor: 'pointer',
+      <Box sx={{ display: 'flex', gap: 2, flexWrap: 'nowrap', minWidth: 'max-content' }}>
+        <Select
+          value={userFilter}
+          onChange={(_, value) => setUserFilter(value || '')}
+          placeholder="All Users"
+          size="sm"
+          sx={{
+            minWidth: 170,
+            border: '1px solid',
+            borderColor: 'neutral.outlinedBorder',
+            borderRadius: 'md',
           }}
         >
-          <option value="all">All Activities</option>
-          <option value="grocery">Groceries Only</option>
-          <option value="payment">Payments Only</option>
-        </select>
+          <Option value="">All Users</Option>
+          {Object.entries(userMap || {}).map(([email, name]) => (
+            <Option key={email} value={email}>{name}</Option>
+          ))}
+        </Select>
+
+        <Input
+          value={textFilter}
+          onChange={e => setTextFilter(e.target.value)}
+          placeholder="Search items..."
+          size="sm"
+          sx={{
+            minWidth: 140,
+            border: '1px solid',
+            borderColor: 'neutral.outlinedBorder',
+            borderRadius: 'md',
+          }}
+        />
+
+        <Input
+          type="date"
+          value={dateRange.from}
+          onChange={e => setDateRange(r => ({ ...r, from: e.target.value }))}
+          size="sm"
+          sx={{
+            minWidth: 140,
+            border: '1px solid',
+            borderColor: 'neutral.outlinedBorder',
+            borderRadius: 'md',
+          }}
+          placeholder="From"
+        />
+
+        <Input
+          type="date"
+          value={dateRange.to}
+          onChange={e => setDateRange(r => ({ ...r, to: e.target.value }))}
+          size="sm"
+          sx={{
+            minWidth: 140,
+            border: '1px solid',
+            borderColor: 'neutral.outlinedBorder',
+            borderRadius: 'md',
+          }}
+          placeholder="To"
+        />
       </Box>
-    </Sheet>
+    </Card>
   );
 }

--- a/src/app/[room_id]/settings/activities/_components/ActivityList.jsx
+++ b/src/app/[room_id]/settings/activities/_components/ActivityList.jsx
@@ -4,34 +4,33 @@ import { Box, Typography } from '@mui/joy';
 import ActivityFilters from './ActivityFilters';
 import ActivityCard from './ActivityCard';
 
-export default function ActivityList({ activities, isAdmin, roomId }) {
-  const [filterType, setFilterType] = useState('all');
+export default function ActivityList({ activities, isAdmin, roomId, userMap }) {
+  const [userFilter, setUserFilter] = useState('');
+  const [textFilter, setTextFilter] = useState('');
+  const [dateRange, setDateRange] = useState({ from: '', to: '' });
 
-  // Filter activities based on selected type
-  const filteredActivities = activities.filter(activity => {
-    if (filterType === 'all') return true;
-    return activity.type === filterType;
+  const filtered = activities.filter(a => {
+    if (userFilter && a.userEmail !== userFilter) return false;
+    if (textFilter && !a.description.toLowerCase().includes(textFilter.toLowerCase())) return false;
+    if (dateRange.from && new Date(a.createdAt) < new Date(dateRange.from)) return false;
+    if (dateRange.to && new Date(a.createdAt) > new Date(dateRange.to + 'T23:59:59')) return false;
+    return true;
   });
 
   return (
-    <Box sx={{
-      maxWidth: '900px',
-      mx: 'auto',
-    }}>
-      {/* Filters */}
+    <Box sx={{ maxWidth: '900px', mx: 'auto' }}>
       <ActivityFilters
-        filterType={filterType}
-        onFilterChange={setFilterType}
+        userFilter={userFilter}
+        setUserFilter={setUserFilter}
+        textFilter={textFilter}
+        setTextFilter={setTextFilter}
+        dateRange={dateRange}
+        setDateRange={setDateRange}
+        userMap={userMap}
       />
 
-      {/* Activities List */}
-      <Box sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 2,
-        mt: 3,
-      }}>
-        {filteredActivities.length === 0 ? (
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 3 }}>
+        {filtered.length === 0 ? (
           <Box sx={{
             textAlign: 'center',
             py: 6,
@@ -41,13 +40,13 @@ export default function ActivityList({ activities, isAdmin, roomId }) {
             borderColor: 'neutral.outlinedBorder',
           }}>
             <Typography level="body-lg" sx={{ color: 'text.secondary' }}>
-              No activities found
+              No pending expenses found
             </Typography>
           </Box>
         ) : (
-          filteredActivities.map((activity) => (
+          filtered.map((activity) => (
             <ActivityCard
-              key={`${activity.type}-${activity.id}`}
+              key={`grocery-${activity.id}`}
               activity={activity}
               isAdmin={isAdmin}
               roomId={roomId}

--- a/src/app/[room_id]/settings/activities/_components/EditActivityDialog.jsx
+++ b/src/app/[room_id]/settings/activities/_components/EditActivityDialog.jsx
@@ -10,16 +10,12 @@ import {
   Input,
   Button,
   Box,
-  Select,
-  Option,
 } from '@mui/joy';
-import { editGroceryActivity, editPaymentActivity } from '../action';
+import { editGroceryActivity } from '../action';
 
 export default function EditActivityDialog({ open, onClose, activity, roomId }) {
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState(null);
-
-  const isGrocery = activity.type === 'grocery';
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -28,13 +24,7 @@ export default function EditActivityDialog({ open, onClose, activity, roomId }) 
     const formData = new FormData(e.target);
 
     startTransition(async () => {
-      let result;
-
-      if (isGrocery) {
-        result = await editGroceryActivity(activity.id, formData);
-      } else {
-        result = await editPaymentActivity(activity.id, formData);
-      }
+      const result = await editGroceryActivity(activity.id, formData);
 
       if (result?.error) {
         setError(result.error);
@@ -46,16 +36,10 @@ export default function EditActivityDialog({ open, onClose, activity, roomId }) 
 
   return (
     <Modal open={open} onClose={onClose}>
-      <ModalDialog
-        sx={{
-          maxWidth: 500,
-          borderRadius: '12px',
-          p: 3,
-        }}
-      >
+      <ModalDialog sx={{ maxWidth: 500, borderRadius: '12px', p: 3 }}>
         <ModalClose />
         <Typography level="h4" sx={{ mb: 3, fontWeight: 700 }}>
-          Edit {isGrocery ? 'Grocery' : 'Payment'} Activity
+          Edit Expense
         </Typography>
 
         {error && (
@@ -74,60 +58,38 @@ export default function EditActivityDialog({ open, onClose, activity, roomId }) 
         )}
 
         <form onSubmit={handleSubmit}>
-          {isGrocery ? (
-            <>
-              {/* Grocery fields */}
-              <FormControl sx={{ mb: 2 }}>
-                <FormLabel>Item Name</FormLabel>
-                <Input
-                  name="material"
-                  defaultValue={activity.description}
-                  required
-                  disabled={isPending}
-                />
-              </FormControl>
+          <FormControl sx={{ mb: 2 }}>
+            <FormLabel>Item Name</FormLabel>
+            <Input
+              name="material"
+              defaultValue={activity.description}
+              required
+              disabled={isPending}
+            />
+          </FormControl>
 
-              <FormControl sx={{ mb: 3 }}>
-                <FormLabel>Amount ($)</FormLabel>
-                <Input
-                  name="money"
-                  type="number"
-                  step="0.01"
-                  defaultValue={activity.amount}
-                  required
-                  disabled={isPending}
-                />
-              </FormControl>
-            </>
-          ) : (
-            <>
-              {/* Payment fields */}
-              <FormControl sx={{ mb: 2 }}>
-                <FormLabel>Amount ($)</FormLabel>
-                <Input
-                  name="amount"
-                  type="number"
-                  step="0.01"
-                  defaultValue={activity.amount}
-                  required
-                  disabled={isPending}
-                />
-              </FormControl>
+          <FormControl sx={{ mb: 2 }}>
+            <FormLabel>Amount (₹)</FormLabel>
+            <Input
+              name="money"
+              type="number"
+              step="0.01"
+              defaultValue={activity.amount}
+              required
+              disabled={isPending}
+            />
+          </FormControl>
 
-              <FormControl sx={{ mb: 3 }}>
-                <FormLabel>Type</FormLabel>
-                <Select
-                  name="status"
-                  defaultValue={activity.paymentType}
-                  required
-                  disabled={isPending}
-                >
-                  <Option value="credit">Credit (Contribution)</Option>
-                  <Option value="debit">Debit (Withdrawal)</Option>
-                </Select>
-              </FormControl>
-            </>
-          )}
+          <FormControl sx={{ mb: 3 }}>
+            <FormLabel>Date</FormLabel>
+            <Input
+              name="created_at"
+              type="date"
+              defaultValue={activity.createdAt?.split('T')[0]}
+              required
+              disabled={isPending}
+            />
+          </FormControl>
 
           <Box sx={{ display: 'flex', gap: 2, justifyContent: 'flex-end' }}>
             <Button
@@ -143,9 +105,7 @@ export default function EditActivityDialog({ open, onClose, activity, roomId }) 
               loading={isPending}
               sx={{
                 backgroundColor: 'blue',
-                '&:hover': {
-                  backgroundColor: 'darkblue',
-                }
+                '&:hover': { backgroundColor: 'darkblue' },
               }}
             >
               Save Changes

--- a/src/app/[room_id]/settings/activities/action.js
+++ b/src/app/[room_id]/settings/activities/action.js
@@ -4,63 +4,43 @@ import { createClient } from '@/utils/supabase/server';
 import { LoginRequired } from '@/policies/LoginRequired';
 import { revalidatePath } from 'next/cache';
 
-/**
- * Edit a grocery activity
- */
 export async function editGroceryActivity(activityId, formData) {
   const session = await LoginRequired();
   const supabase = await createClient();
-  // Get current user and verify admin role
-  console.log('edit grocerry item action')
+
   const { data: currentUser } = await supabase
     .from('Users')
-    .select('role, room')
+    .select('role, room, id')
     .eq('email', session.user.email)
     .single();
 
   if (currentUser?.role !== 'Admin') {
     return { error: 'Only admins can edit activities' };
   }
-  console.log(currentUser, "------------------")
+
   const material = formData.get('material');
   const money = parseFloat(formData.get('money'));
+  const created_at = formData.get('created_at');
   const roomId = currentUser.room;
-console.log(material,money)
 
-  // Update the grocery activity
-  console.log('[DB UPDATE] Attempting to update Spendings table - activityId:', activityId, 'material:', material, 'money:', money);
-
-  const { data: updateData, error: updateError } = await supabase
+  const { error: updateError } = await supabase
     .from('Spendings')
-    .update({
-      material,
-      money,
-    })
-    .eq('id', activityId)
-    .select();
-
-  console.log('[DB UPDATE] Query executed - Rows returned:', updateData?.length, 'Data:', JSON.stringify(updateData));
+    .update({ material, money, created_at })
+    .eq('id', activityId);
 
   if (updateError) {
-    console.error('[DB UPDATE] ERROR during update:', JSON.stringify(updateError));
-    return { error: 'Failed to update grocery activity' };
+    console.error('Error updating grocery:', updateError);
+    return { error: 'Failed to update expense' };
   }
 
-  if (!updateData || updateData.length === 0) {
-    console.error('[DB UPDATE] WARNING - No rows were updated! ActivityId might not exist:', activityId);
-  } else {
-    console.log('[DB UPDATE] SUCCESS - Database updated successfully');
-  }
-
-  // Create notification for all room members
   await supabase
     .from('Notifications')
     .insert({
       room_id: roomId,
       triggered_by: currentUser.id,
       activity_type: 'grocery',
-      title: 'Activity Edited',
-      message: `Admin edited a grocery item: ${material} - $${money}`,
+      title: 'Expense Edited',
+      message: `Admin edited an expense: ${material} - ₹${money}`,
       data: { activityId, type: 'edit' }
     });
 
@@ -68,70 +48,13 @@ console.log(material,money)
   return { success: true };
 }
 
-/**
- * Edit a payment activity
- */
-export async function editPaymentActivity(activityId, formData) {
-  const session = await LoginRequired();
-  const supabase = await createClient();
-
-  // Get current user and verify admin role
-  const { data: currentUser } = await supabase
-    .from('Users')
-    .select('role, room')
-    .eq('email', session.user.email)
-    .single();
-
-  if (currentUser?.role !== 'Admin') {
-    return { error: 'Only admins can edit activities' };
-  }
-
-  const amount = parseFloat(formData.get('amount'));
-  const status = formData.get('status'); // 'credit' or 'debit'
-  const roomId = currentUser.room;
-
-  // Update the payment activity
-  const { error: updateError } = await supabase
-    .from('balance')
-    .update({
-      amount,
-      status,
-    })
-    .eq('id', activityId);
-
-  if (updateError) {
-    console.error('Error updating payment:', updateError);
-    return { error: 'Failed to update payment activity' };
-  }
-
-  // Create notification for all room members
-  const actionType = status === 'credit' ? 'contributed' : 'withdrew';
-  await supabase
-    .from('Notifications')
-    .insert({
-      room_id: roomId,
-      triggered_by: currentUser.id,
-      activity_type: 'payment',
-      title: 'Activity Edited',
-      message: `Admin edited a payment: ${actionType} $${amount}`,
-      data: { activityId, type: 'edit' }
-    });
-
-  revalidatePath(`/${roomId}`, 'layout');
-  return { success: true };
-}
-
-/**
- * Delete a grocery activity
- */
 export async function deleteGroceryActivity(activityId, material, money) {
   const session = await LoginRequired();
   const supabase = await createClient();
 
-  // Get current user and verify admin role
   const { data: currentUser } = await supabase
     .from('Users')
-    .select('role, room')
+    .select('role, room, id')
     .eq('email', session.user.email)
     .single();
 
@@ -141,7 +64,6 @@ export async function deleteGroceryActivity(activityId, material, money) {
 
   const roomId = currentUser.room;
 
-  // Delete the grocery activity
   const { error: deleteError } = await supabase
     .from('Spendings')
     .delete()
@@ -149,66 +71,17 @@ export async function deleteGroceryActivity(activityId, material, money) {
 
   if (deleteError) {
     console.error('Error deleting grocery:', deleteError);
-    return { error: 'Failed to delete grocery activity' };
+    return { error: 'Failed to delete expense' };
   }
 
-  // Create notification for all room members
   await supabase
     .from('Notifications')
     .insert({
       room_id: roomId,
       triggered_by: currentUser.id,
       activity_type: 'grocery',
-      title: 'Activity Deleted',
-      message: `Admin deleted a grocery item: ${material} - $${money}`,
-      data: { activityId, type: 'delete' }
-    });
-
-  revalidatePath(`/${roomId}`, 'layout');
-  return { success: true };
-}
-
-/**
- * Delete a payment activity
- */
-export async function deletePaymentActivity(activityId, amount, status) {
-  const session = await LoginRequired();
-  const supabase = await createClient();
-
-  // Get current user and verify admin role
-  const { data: currentUser } = await supabase
-    .from('Users')
-    .select('role, room')
-    .eq('email', session.user.email)
-    .single();
-
-  if (currentUser?.role !== 'Admin') {
-    return { error: 'Only admins can delete activities' };
-  }
-
-  const roomId = currentUser.room;
-
-  // Delete the payment activity
-  const { error: deleteError } = await supabase
-    .from('balance')
-    .delete()
-    .eq('id', activityId);
-
-  if (deleteError) {
-    console.error('Error deleting payment:', deleteError);
-    return { error: 'Failed to delete payment activity' };
-  }
-
-  // Create notification for all room members
-  const actionType = status === 'credit' ? 'contribution' : 'withdrawal';
-  await supabase
-    .from('Notifications')
-    .insert({
-      room_id: roomId,
-      triggered_by: currentUser.id,
-      activity_type: 'payment',
-      title: 'Activity Deleted',
-      message: `Admin deleted a payment ${actionType}: $${amount}`,
+      title: 'Expense Deleted',
+      message: `Admin deleted an expense: ${material} - ₹${money}`,
       data: { activityId, type: 'delete' }
     });
 

--- a/src/app/[room_id]/settings/activities/page.jsx
+++ b/src/app/[room_id]/settings/activities/page.jsx
@@ -21,18 +21,12 @@ export default async function ActivitiesPage({ params }) {
 
   const isAdmin = currentUser?.role === 'Admin';
 
-  // Fetch groceries (Spendings)
-  const { data: groceries, error: groceriesError } = await supabase
+  // Fetch only unsettled groceries (Spendings)
+  const { data: groceries } = await supabase
     .from('Spendings')
-    .select('id, user, material, money, created_at')
+    .select('id, user, material, money, created_at, settled')
     .eq('room', room_id)
-    .order('created_at', { ascending: false });
-
-  // Fetch payments (Balance - both credits and debits)
-  const { data: payments, error: paymentsError } = await supabase
-    .from('balance')
-    .select('id, user, amount, status, created_at')
-    .eq('room', room_id)
+    .or('settled.is.null,settled.eq.false')
     .order('created_at', { ascending: false });
 
   // Fetch all users in the room to get their names
@@ -43,35 +37,23 @@ export default async function ActivitiesPage({ params }) {
 
   // Create a map for quick user lookup
   const userMap = {};
+  const emailToName = {};
   roomUsers?.forEach(user => {
     userMap[user.id] = user.name || user.email;
     userMap[user.email] = user.name || user.email;
+    emailToName[user.email] = user.name || user.email;
   });
 
-  // Transform groceries
-  const groceryActivities = groceries?.map(grocery => ({
+  // Transform groceries — keep raw email for client-side filtering
+  const allActivities = groceries?.map(grocery => ({
     id: grocery.id,
     type: 'grocery',
     user: userMap[grocery.user] || grocery.user,
+    userEmail: grocery.user,
     amount: grocery.money,
     description: grocery.material,
     createdAt: grocery.created_at,
   })) || [];
-
-  // Transform payments
-  const paymentActivities = payments?.map(payment => ({
-    id: payment.id,
-    type: 'payment',
-    user: userMap[payment.user] || payment.user,
-    amount: payment.amount,
-    description: payment.status === 'credit' ? 'Money Contributed' : 'Money Withdrawn',
-    paymentType: payment.status,
-    createdAt: payment.created_at,
-  })) || [];
-
-  // Combine and sort by date (newest first)
-  const allActivities = [...groceryActivities, ...paymentActivities]
-    .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
 
   return (
     <Box sx={{
@@ -95,6 +77,7 @@ export default async function ActivitiesPage({ params }) {
         activities={allActivities}
         isAdmin={isAdmin}
         roomId={room_id}
+        userMap={emailToName}
       />
     </Box>
   );


### PR DESCRIPTION
## Summary

- Activity History page now shows **only pending (unsettled) grocery expenses** — settled expenses and payments are no longer listed
- Replaced the simple type-filter dropdown with a rich **filter bar**: user dropdown, item text search, date-from, date-to (matches expense history page style)
- Admin can now edit **item name, price, and date** on any pending expense, and delete it
- Removed payment edit/delete server actions (dead code cleanup)

## Test plan

- [ ] Open `/[room_id]/settings/activities` — only unsettled grocery expenses should appear
- [ ] Verify settled expenses and payment records are not shown
- [ ] Filter by user, search text, and date range and confirm correct results
- [ ] As admin: click Edit on an expense → update name, price, date → verify saved correctly
- [ ] As admin: click Delete → confirm dialog → expense removed from list
- [ ] As non-admin: confirm no edit/delete buttons are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)