### PR TITLE
docs: add code of conduct for contributors

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as contributors and maintainers pledge to make participation in RoomGrub an open and welcoming experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+**Positive behaviors include:**
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the project and community
+- Showing empathy towards other contributors
+
+**Unacceptable behaviors include:**
+
+- Harassment, insulting, or derogatory comments in any form
+- Personal or political attacks
+- Publishing others' private information without explicit permission
+- Trolling or deliberately disruptive behavior
+- Any conduct that would reasonably be considered inappropriate in a professional setting
+
+## Responsibilities
+
+Project maintainers are responsible for clarifying acceptable behavior and are expected to take fair corrective action in response to any unacceptable behavior.
+
+Maintainers have the right to remove, edit, or reject comments, commits, code, issues, and other contributions that do not align with this Code of Conduct, and may temporarily or permanently ban any contributor for behaviors they deem inappropriate, threatening, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces — including GitHub issues, pull requests, commit messages, and any other project-related communication — and also applies when an individual is representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project maintainer at **sankar.s@imgearsindia.com**. All complaints will be reviewed and investigated promptly and fairly. Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.


### PR DESCRIPTION
## Summary
- Adds `CODE_OF_CONDUCT.md` to the repository root
- Covers contributor pledge, acceptable/unacceptable behaviors, enforcement, and attribution to the Contributor Covenant v2.1

## Test plan
- [ ] Verify file renders correctly on GitHub
- [ ] Confirm PR targets `main`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)