### PR TITLE
fix: disable future dates in expense date picker

### DIFF
--- a/src/app/[room_id]/addgroccery/_components/AddGroccery.jsx
+++ b/src/app/[room_id]/addgroccery/_components/AddGroccery.jsx
@@ -89,6 +89,7 @@ function ExpenseScreen({
                     ref={dateInputRef}
                     type="date"
                     value={date}
+                    max={new Date().toISOString().split('T')[0]}
                     onChange={e => onDatePick(e.target.value)}
                     className="sr-only"
                     aria-hidden="true"


### PR DESCRIPTION
## Summary
- Adds `max` attribute to the date input in `ExpenseScreen`, restricting selection to today or earlier
- Applies to both the personal expense flow and the "add for friend" flow (shared component)

## Test plan
- [ ] Open the Add Expense page
- [ ] Click the date button and verify future dates are greyed out / unselectable
- [ ] Confirm past dates and today are still selectable
- [ ] Repeat via the "Friend" expense screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)