### PR TITLE
Fix member link id mismatch and unify add-expense form

### DIFF
--- a/src/app/[room_id]/addgroccery/_components/AddGroccery.jsx
+++ b/src/app/[room_id]/addgroccery/_components/AddGroccery.jsx
@@ -123,13 +123,6 @@ export default function AddGrocery({ userRole }) {
     const [loading, setLoading] = useState(false);
     const [msg, setMsg] = useState('');
 
-    const [showFriendScreen, setShowFriendScreen] = useState(false);
-    const [friendAmount, setFriendAmount] = useState('');
-    const [friendDescription, setFriendDescription] = useState('');
-    const [friendDate, setFriendDate] = useState('');
-    const [friendLoading, setFriendLoading] = useState(false);
-    const [friendMsg, setFriendMsg] = useState('');
-
     const [roomMembers, setRoomMembers] = useState([]);
     const [currentUser, setCurrentUser] = useState(null);
     const [currentUserEmail, setCurrentUserEmail] = useState(null);
@@ -139,17 +132,8 @@ export default function AddGrocery({ userRole }) {
     const amountInputRef = useRef(null);
     const descriptionInputRef = useRef(null);
     const dateInputRef = useRef(null);
-    const friendAmountInputRef = useRef(null);
-    const friendDescriptionInputRef = useRef(null);
-    const friendDateInputRef = useRef(null);
 
     const params = useParams();
-
-    useEffect(() => {
-        if (showFriendScreen) {
-            setTimeout(() => friendAmountInputRef.current?.focus(), 100);
-        }
-    }, [showFriendScreen]);
 
     useEffect(() => {
         getRoomMembersForRoom(params.room_id).then(({ members, currentUser: me, currentUserEmail: email }) => {
@@ -169,9 +153,13 @@ export default function AddGrocery({ userRole }) {
         setMsg('');
         if (!description || parseFloat(amount) <= 0) { setMsg('Please enter amount and description.'); return; }
         setLoading(true);
-        const result = await addExpense(params.room_id, description, amount, date, currentUserEmail);
+
+        const result = selectedFriend && selectedFriend.email !== currentUserEmail
+            ? await addGroceryForFriend(params.room_id, selectedFriend.email, description, amount, date)
+            : await addExpense(params.room_id, description, amount, date, currentUserEmail);
+
         if (result.success) {
-            setMsg('✅ Expense added!');
+            setMsg('✅ ' + (result.message || 'Expense added!'));
             setAmount(''); setDescription(''); setDate('');
             setTimeout(() => { setMsg(''); amountInputRef.current?.focus(); }, 1500);
         } else {
@@ -180,38 +168,10 @@ export default function AddGrocery({ userRole }) {
         setLoading(false);
     };
 
-    const openFriendScreen = () => {
-        setFriendAmount(''); setFriendDescription(''); setFriendDate(''); setFriendMsg('');
-        setShowFriendScreen(true);
-    };
-
-    const handleFriendAdd = async () => {
-        setFriendMsg('');
-        if (!friendDescription || parseFloat(friendAmount) <= 0) { setFriendMsg('Please enter amount and description.'); return; }
-        if (!selectedFriend) { setFriendMsg('Please select a friend.'); return; }
-        setFriendLoading(true);
-
-        const targetEmail = selectedFriend.email === currentUserEmail
-            ? currentUserEmail
-            : selectedFriend.email;
-
-        const result = selectedFriend.email === currentUserEmail
-            ? await addExpense(params.room_id, friendDescription, friendAmount, friendDate, currentUserEmail)
-            : await addGroceryForFriend(params.room_id, selectedFriend.email, friendDescription, friendAmount, friendDate);
-
-        if (result.success) {
-            setFriendMsg('✅ ' + (result.message || 'Expense added!'));
-            setTimeout(() => setShowFriendScreen(false), 1200);
-        } else {
-            setFriendMsg('❌ ' + result.error);
-        }
-        setFriendLoading(false);
-    };
-
     const friendSelectorSlot = (
         <div className="relative">
             <button
-                onClick={() => userRole === 'Admin' && setShowMemberPicker(p => !p)}
+                onClick={() => setShowMemberPicker(p => !p)}
                 className="flex items-center gap-2 text-sm text-purple-600 bg-purple-50 border border-purple-200 rounded-full pl-1 pr-3 py-1 active:bg-purple-100 select-none font-medium"
             >
                 <Avatar
@@ -221,7 +181,7 @@ export default function AddGrocery({ userRole }) {
                     sx={{ width: 26, height: 26 }}
                 />
                 <span>{selectedFriend?.email === currentUserEmail ? 'Me' : (selectedFriend?.name || 'Select')}</span>
-                {userRole === 'Admin' && <span className="text-purple-400 text-xs">▾</span>}
+                <span className="text-purple-400 text-xs">▾</span>
             </button>
             {showMemberPicker && (
                 <div className="absolute bottom-full mb-2 left-0 bg-white rounded-2xl shadow-xl border border-purple-100 py-2 min-w-[180px] z-10">
@@ -245,31 +205,6 @@ export default function AddGrocery({ userRole }) {
         </div>
     );
 
-    if (showFriendScreen) {
-        return (
-            <ExpenseScreen
-                title="Add Expense for Friend"
-                amount={friendAmount}
-                description={friendDescription}
-                date={friendDate}
-                loading={friendLoading}
-                msg={friendMsg}
-                onAmountChange={e => { const v = parseAmountInput(e.target.value); if (v !== null) setFriendAmount(v); }}
-                onAmountKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); friendDescriptionInputRef.current?.focus(); } }}
-                onDescriptionChange={e => setFriendDescription(e.target.value)}
-                onDescriptionKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); e.target.blur(); } }}
-                onSubmit={handleFriendAdd}
-                onDatePick={setFriendDate}
-                formattedDate={formattedDate(friendDate)}
-                amountInputRef={friendAmountInputRef}
-                descriptionInputRef={friendDescriptionInputRef}
-                dateInputRef={friendDateInputRef}
-                submitLabel={`Add for ${selectedFriend?.email === currentUserEmail ? 'Me' : (selectedFriend?.name || 'Friend')}`}
-                friendSlot={friendSelectorSlot}
-            />
-        );
-    }
-
     return (
         <ExpenseScreen
             title="Add Expense"
@@ -288,15 +223,11 @@ export default function AddGrocery({ userRole }) {
             amountInputRef={amountInputRef}
             descriptionInputRef={descriptionInputRef}
             dateInputRef={dateInputRef}
-            friendSlot={
-                userRole === 'Admin' ? (
-                    <button
-                        onClick={openFriendScreen}
-                        className="flex items-center gap-1.5 text-sm text-purple-600 bg-purple-50 border border-purple-200 rounded-full px-4 py-2 active:bg-purple-100 select-none font-medium"
-                    >
-                        👥 Friend
-                    </button>
-                ) : null
+            friendSlot={userRole === 'Admin' ? friendSelectorSlot : null}
+            submitLabel={
+                userRole === 'Admin' && selectedFriend?.email !== currentUserEmail
+                    ? `Add for ${selectedFriend?.name || 'Friend'}`
+                    : 'Add Expense'
             }
         />
     );

--- a/src/app/[room_id]/members/_components/ListMembers.jsx
+++ b/src/app/[room_id]/members/_components/ListMembers.jsx
@@ -137,7 +137,7 @@ export default function ListMembers({ members, roomId, currentUserEmail }) {
                                     transition: 'all 0.2s',
                                 },
                             }}
-                            onClick={() => router.push(`/${roomId}/members/${member.id}`)}
+                            onClick={() => router.push(`/${roomId}/members/${member.user_id}`)}
                         >
                             <CardContent>
                                 <Stack direction="row" spacing={2} alignItems="center" justifyContent="space-between">


### PR DESCRIPTION
## Summary
- Members list now links to `/members/{user_id}` instead of the membership-junction row id, so it matches the identifier the room dashboard uses — clicking a member from either entry point now routes to the correct member. (Backend endpoints for member detail/settle/contribute/role need to accept `user_id` for this to fully resolve; frontend is now consistent on its own.)
- Merged the duplicate self/friend screens in the Add Expense page into a single form: switching the friend dropdown selection no longer resets the amount/description already typed, and the friend selector is now a direct dropdown (default "Me") instead of requiring a button click before the dropdown appears.

## Test plan
- [ ] From the room dashboard, click a member card and confirm it opens the correct member detail page
- [ ] From the members page, click a member card and confirm it opens the correct member detail page
- [ ] On Add Expense, type an amount and description, then switch the friend dropdown — confirm values are preserved
- [ ] Confirm the friend dropdown opens directly on first click (no intermediate "Friend" button)
- [ ] Submit an expense for self and for another member, confirm both succeed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sambhusankar/RoomGrub/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now add groceries for a selected friend directly from the main expense screen, without switching to a separate friend-specific view.
  * The action label now updates based on whether you’re adding for yourself or another person.

* **Bug Fixes**
  * Improved success and error messages when submitting grocery entries.
  * Member cards now open the correct member profile or details page when selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->