### PR TITLE
Release v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # Changelog
 
-## Unreleased
+## 4.0.0
 
 ### Changed
 - Migrated persistence and business logic from Supabase (Postgres + auth) to a separate Python FastAPI backend. This app now acts purely as a BFF (backend-for-frontend), proxying requests to the backend via `backendJson()` / Next.js API routes instead of querying the database directly.
 - Replaced Supabase Auth with Google Identity Services (`@react-oauth/google`). Login now exchanges a Google `id_token` for a backend-issued JWT, stored in the `rg_token` httpOnly cookie.
 - Reworked `middleware.js` (dropped the old `middleware.ts`) to gate routes based on `rg_token` presence/expiry instead of Supabase session cookies.
 - Fixed invited by user name
+- Moved the "My Rooms" dashboard from `/` to `/rooms`; `/` now redirects to `/rooms`.
+
+### Fixed
+- Post-login redirect no longer requires closing/reopening the app: replaced client-side `router.push` (which didn't reliably pick up the freshly-set auth cookie) with a hard `window.location.href` navigation after login and after invite acceptance.
+- Promoting/demoting a room member (and removing a member) no longer fails with "Member not found" — `findMemberIdByEmail` was resolving the wrong id field (`id` instead of `user_id`) from the members list, which the backend's member sub-resource routes require.
 
 ### Removed
 - Supabase client/server/middleware helpers (`src/utils/supabase/*`) and all Mongoose-style data models (`src/database/*`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "room-grub",
-  "version": "0.1.0",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "room-grub",
-      "version": "0.1.0",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "@ducanh2912/next-pwa": "^10.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "room-grub",
-  "version": "0.1.0",
+  "version": "4.0.0",
   "private": true,
   "license": "MIT",
   "scripts": {

--- a/src/app/(auth)/login/_components/login_btn.jsx
+++ b/src/app/(auth)/login/_components/login_btn.jsx
@@ -1,11 +1,9 @@
 'use client'
 import { GoogleLogin } from '@react-oauth/google'
-import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { apiCall } from '@/utils/api'
 
 export default function LoginBtn({ inviteToken }) {
-    const router = useRouter()
     const [error, setError] = useState(null)
 
     const handleSuccess = async (credentialResponse) => {
@@ -20,8 +18,7 @@ export default function LoginBtn({ inviteToken }) {
                 try {
                     const invite = await apiCall(`/api/invites/${inviteToken}/accept`, { method: 'POST' })
                     if (invite?.room_id) {
-                        router.refresh()
-                        router.push(`/${invite.room_id}`)
+                        window.location.href = `/${invite.room_id}`
                         return
                     }
                 } catch {
@@ -29,8 +26,7 @@ export default function LoginBtn({ inviteToken }) {
                 }
             }
 
-            router.refresh()
-            router.push('/')
+            window.location.href = '/rooms'
         } catch {
             setError('Login failed. Please try again.')
         }

--- a/src/app/[room_id]/members/actions.js
+++ b/src/app/[room_id]/members/actions.js
@@ -16,7 +16,7 @@ export async function getMembers(roomId) {
 async function findMemberIdByEmail(roomId, email) {
     const members = await backendJson(`/api/v1/rooms/${roomId}/members`);
     const member = (members || []).find(m => m.email === email);
-    return member?.id ?? null;
+    return member?.user_id ?? null;
 }
 
 export async function updateMemberRole(roomId, memberEmail, newRole) {

--- a/src/app/[room_id]/settings/_components/DangerZone.jsx
+++ b/src/app/[room_id]/settings/_components/DangerZone.jsx
@@ -25,7 +25,7 @@ export default function DangerZone({ roomId }) {
         try {
             const result = await deleteRoom(roomId);
             if (result.success) {
-                router.push('/');
+                router.push('/rooms');
             } else {
                 setError(result.error);
                 if (result.pendingExists) setPendingExists(true);

--- a/src/app/invite/[token]/page.jsx
+++ b/src/app/invite/[token]/page.jsx
@@ -88,7 +88,7 @@ export default function InvitePage() {
     setError('');
     const result = await rejectInvite(token);
     if (result.success) {
-      router.push('/');
+      router.push('/rooms');
     } else {
       setError(result.error || 'Failed to decline invite');
       setActionLoading(false);

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,13 +1,5 @@
-import { LoginRequired } from '@/policies/LoginRequired';
-import NavBarContainer from '@/components/NavBarContainer';
-import RoomsPage from './_components/RoomsPage';
+import { redirect } from 'next/navigation';
 
-export default async function Home() {
-  await LoginRequired();
-
-  return (
-    <NavBarContainer>
-      <RoomsPage />
-    </NavBarContainer>
-  );
+export default function Home() {
+  redirect('/rooms');
 }

--- a/src/app/rooms/_components/RoomsPage.jsx
+++ b/src/app/rooms/_components/RoomsPage.jsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { getUserRooms } from '../actions';
+import { getUserRooms } from '../../actions';
 import Box from '@mui/joy/Box';
 import CircularProgress from '@mui/joy/CircularProgress';
 import Button from '@mui/joy/Button';

--- a/src/app/rooms/page.js
+++ b/src/app/rooms/page.js
@@ -1,0 +1,13 @@
+import { LoginRequired } from '@/policies/LoginRequired';
+import NavBarContainer from '@/components/NavBarContainer';
+import RoomsPage from './_components/RoomsPage';
+
+export default async function Home() {
+  await LoginRequired();
+
+  return (
+    <NavBarContainer>
+      <RoomsPage />
+    </NavBarContainer>
+  );
+}

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -51,7 +51,7 @@ export default function NavBar({ user, signOut }) {
     setMenuOpen(false);
     const result = await exitRoom(room_id);
     if (result.success) {
-      router.push('/');
+      router.push('/rooms');
     } else {
       alert(`Error: ${result.error}`);
     }
@@ -64,7 +64,7 @@ export default function NavBar({ user, signOut }) {
       {room_id ? (
         <div className="flex items-center gap-2">
           <button
-            onClick={() => router.push('/')}
+            onClick={() => router.push('/rooms')}
             className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-purple-100 text-purple-600 transition-colors"
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/policies/validRoom.js
+++ b/src/policies/validRoom.js
@@ -21,7 +21,7 @@ export const validRoom = async ({ params }) => {
     const { data: membership, error } = await getUserRoomForRoom(session.user.email, roomId)
 
     if (error || !membership) {
-      redirect('/')
+      redirect('/rooms')
     }
 
     return { room: membership.room_id, role: membership.role }


### PR DESCRIPTION
## Summary
- Fix post-login redirect requiring an app restart — switched to a hard navigation (`window.location.href`) so the freshly-set `rg_token` cookie is picked up by middleware immediately.
- Move the rooms dashboard from `/` to `/rooms`; `/` now redirects to `/rooms`.
- Fix "Member not found" on promote/demote/remove member — `findMemberIdByEmail` now resolves `user_id` instead of the members-list record's `id`, matching the id the backend's member sub-resource routes expect.
- Bump version to 4.0.0 and update CHANGELOG.md.

## Test plan
- [x] `npm test` passes
- [x] `npm run build` succeeds, route table shows `/rooms` and `/` (redirect)
- [ ] Manually verify: log in → lands on `/rooms` without restart
- [ ] Manually verify: promote/demote/remove a member succeeds
- [ ] Manually verify: visiting `/` while logged in redirects to `/rooms`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sambhusankar/RoomGrub/pull/56?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated `/rooms` page for viewing rooms.
  * Updated the home route to redirect to `/rooms`.
  * Added documented API, authentication, and navigation updates for version 4.0.0.

* **Bug Fixes**
  * Improved login and invite navigation to correctly recognize authentication.
  * Fixed room-member actions that could incorrectly report “Member not found.”
  * Updated room deletion, invitation rejection, and room exit redirects to return to `/rooms`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->