### PR TITLE
feat: Google One Tap login via FedCM and faster post-login flow

### DIFF
--- a/src/app/(auth)/login/_components/login_btn.jsx
+++ b/src/app/(auth)/login/_components/login_btn.jsx
@@ -1,14 +1,17 @@
 'use client'
 import { GoogleLogin } from '@react-oauth/google'
 import { useState } from 'react'
+import CircularProgress from '@mui/joy/CircularProgress'
 import { apiCall } from '@/utils/api'
 
 export default function LoginBtn({ inviteToken }) {
     const [error, setError] = useState(null)
+    const [loading, setLoading] = useState(false)
 
     const handleSuccess = async (credentialResponse) => {
         try {
             setError(null)
+            setLoading(true)
             await apiCall('/api/auth/login', {
                 method: 'POST',
                 body: JSON.stringify({ provider: 'google', token: credentialResponse.credential }),
@@ -28,8 +31,18 @@ export default function LoginBtn({ inviteToken }) {
 
             window.location.href = '/rooms'
         } catch {
+            setLoading(false)
             setError('Login failed. Please try again.')
         }
+    }
+
+    if (loading) {
+        return (
+            <div className="flex flex-col items-center gap-3">
+                <CircularProgress size="md" />
+                <p className="text-sm text-gray-500">Signing you in…</p>
+            </div>
+        )
     }
 
     return (
@@ -37,6 +50,12 @@ export default function LoginBtn({ inviteToken }) {
             <GoogleLogin
                 onSuccess={handleSuccess}
                 onError={() => setError('Google login failed. Please try again.')}
+                useOneTap
+                use_fedcm_for_prompt
+                use_fedcm_for_button
+                itp_support
+                auto_select={false}
+                cancel_on_tap_outside={false}
                 theme="outline"
                 shape="pill"
                 size="large"

--- a/src/app/actions.js
+++ b/src/app/actions.js
@@ -13,6 +13,6 @@ export async function getUserRooms() {
         const rooms = await backendJson('/api/v1/rooms');
         return { rooms: rooms || [], firstName };
     } catch {
-        return { rooms: [], firstName };
+        return { rooms: [], firstName, error: true };
     }
 }

--- a/src/app/invite/[token]/page.jsx
+++ b/src/app/invite/[token]/page.jsx
@@ -27,6 +27,7 @@ export default function InvitePage() {
   const [invalidReason, setInvalidReason] = useState('');
   const [session, setSession] = useState(null);
   const [error, setError] = useState('');
+  const [signingIn, setSigningIn] = useState(false);
 
   useEffect(() => {
     const init = async () => {
@@ -54,6 +55,8 @@ export default function InvitePage() {
 
   const handleGoogleLogin = async (credentialResponse) => {
     try {
+      setError('');
+      setSigningIn(true);
       await apiCall('/api/auth/login', {
         method: 'POST',
         body: JSON.stringify({ provider: 'google', token: credentialResponse.credential }),
@@ -65,8 +68,10 @@ export default function InvitePage() {
       } else {
         const userCookie = document.cookie.split('; ').find(r => r.startsWith('rg_user='));
         setSession(userCookie ? JSON.parse(decodeURIComponent(userCookie.split('=')[1])) : null);
+        setSigningIn(false);
       }
     } catch {
+      setSigningIn(false);
       setError('Login failed. Please try again.');
     }
   };
@@ -141,13 +146,24 @@ export default function InvitePage() {
             <strong>{inviterName}</strong> invited you to join <strong>{roomLabel}</strong> on RoomGrub.
           </p>
           <p style={styles.expiry}>Link expires in {invite.daysLeft} day{invite.daysLeft !== 1 ? 's' : ''}</p>
-          <GoogleLogin
-            onSuccess={handleGoogleLogin}
-            onError={() => setError('Google login failed')}
-            theme="outline"
-            shape="pill"
-            size="large"
-          />
+          {error && <p style={styles.errorText}>{error}</p>}
+          {signingIn ? (
+            <p style={styles.subtitle}>Signing you in…</p>
+          ) : (
+            <GoogleLogin
+              onSuccess={handleGoogleLogin}
+              onError={() => setError('Google login failed')}
+              useOneTap
+              use_fedcm_for_prompt
+              use_fedcm_for_button
+              itp_support
+              auto_select={false}
+              cancel_on_tap_outside={false}
+              theme="outline"
+              shape="pill"
+              size="large"
+            />
+          )}
         </div>
       </div>
     );

--- a/src/app/rooms/_components/RoomsPage.jsx
+++ b/src/app/rooms/_components/RoomsPage.jsx
@@ -12,13 +12,19 @@ import CardContent from '@mui/joy/CardContent';
 
 const ROOMS_CACHE_KEY = 'roomgrub_user_rooms';
 
-export default function RoomsPage() {
+export default function RoomsPage({ initialData }) {
   const router = useRouter();
-  const [rooms, setRooms] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [firstName, setFirstName] = useState('');
+  const hasInitial = Boolean(initialData && !initialData.error);
+  const [rooms, setRooms] = useState(hasInitial ? initialData.rooms : null);
+  const [loading, setLoading] = useState(!hasInitial);
+  const [firstName, setFirstName] = useState(initialData?.firstName || '');
 
   useEffect(() => {
+    if (hasInitial) {
+      localStorage.setItem(ROOMS_CACHE_KEY, JSON.stringify(initialData.rooms));
+      return;
+    }
+
     const loadRooms = async () => {
       const cachedRaw = typeof localStorage !== 'undefined' ? localStorage.getItem(ROOMS_CACHE_KEY) : null;
       const cached = cachedRaw ? JSON.parse(cachedRaw) : null;
@@ -30,10 +36,14 @@ export default function RoomsPage() {
       }
 
       try {
-        const { rooms: roomList, firstName: name } = await getUserRooms();
-        setFirstName(name);
-        localStorage.setItem(ROOMS_CACHE_KEY, JSON.stringify(roomList));
-        setRooms(roomList);
+        const { rooms: roomList, firstName: name, error: fetchError } = await getUserRooms();
+        if (fetchError) {
+          setRooms(cached || []);
+        } else {
+          setFirstName(name);
+          localStorage.setItem(ROOMS_CACHE_KEY, JSON.stringify(roomList));
+          setRooms(roomList);
+        }
       } catch {
         setRooms(cached || []);
       }
@@ -41,7 +51,7 @@ export default function RoomsPage() {
     };
 
     loadRooms();
-  }, []);
+  }, [hasInitial, initialData]);
 
   if (loading || rooms === null) {
     return (

--- a/src/app/rooms/page.js
+++ b/src/app/rooms/page.js
@@ -1,13 +1,15 @@
 import { LoginRequired } from '@/policies/LoginRequired';
 import NavBarContainer from '@/components/NavBarContainer';
+import { getUserRooms } from '../actions';
 import RoomsPage from './_components/RoomsPage';
 
 export default async function Home() {
   await LoginRequired();
+  const initialData = await getUserRooms();
 
   return (
     <NavBarContainer>
-      <RoomsPage />
+      <RoomsPage initialData={initialData} />
     </NavBarContainer>
   );
 }

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -2,6 +2,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import Image from 'next/image';
+import { googleLogout } from '@react-oauth/google';
 import useUserRole from '@/hooks/useUserRole';
 import { exitRoom } from '@/app/[room_id]/members/actions';
 
@@ -43,6 +44,7 @@ export default function NavBar({ user, signOut }) {
 
   function handleSignOut() {
     setMenuOpen(false);
+    googleLogout();
     signOut();
   }
 


### PR DESCRIPTION
## Summary
- Login now uses **Google One Tap with FedCM**: opening `/login` (or an invite link) shows the browser-native account picker — tap your account and you're in, no popup redirect to Google's "Continue/Cancel" page. The classic Google button remains as fallback (One Tap cooldown, iOS Safari).
- Fixed the perceived post-login hang: a "Signing you in…" indicator shows while the backend exchanges the Google credential, and `/rooms` now prefetches the room list server-side so it renders with data instead of a second spinner.
- `getUserRooms` distinguishes backend failure from an empty room list, so the client falls back to the cached rooms instead of showing a false "no rooms" state; sign-out calls `googleLogout()` so One Tap re-prompts cleanly.

## Deployment note
One Tap requires the app origins under **Authorized JavaScript origins** in Google Cloud Console (production domain; for local dev both `http://localhost` and `http://localhost:3001`). If missing, One Tap silently doesn't display and only the fallback button works.

## Testing
- `npm test` (16 passed) and production build pass.
- Verified on desktop Chrome: One Tap sheet appears on `/login`, account tap signs in and lands on `/rooms` with rooms pre-rendered.
- Note: Chrome DevTools mobile *emulation* misfires taps on the One Tap sheet (`tap_outside`) — test mobile on a real device (e.g. `adb reverse tcp:3001 tcp:3001`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJncUKUnu9pBpZFGq6mv2U

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sambhusankar/RoomGrub/pull/57?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading indicators and “Signing you in…” messages during Google authentication.
  * Improved Google sign-in behavior and configuration for login and invitation flows.
  * Added server-side room data loading to improve initial page rendering.

* **Bug Fixes**
  * Room loading now falls back to cached data when fetching fails.
  * Login errors now display a clearer message.
  * Logging out now properly ends the Google session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->