### PR TITLE
fix: gate FedCM button flow by browser support so login button render…

### DIFF
--- a/src/app/(auth)/login/_components/login_btn.jsx
+++ b/src/app/(auth)/login/_components/login_btn.jsx
@@ -1,7 +1,7 @@
 'use client'
-import { GoogleLogin } from '@react-oauth/google'
 import { useState } from 'react'
 import CircularProgress from '@mui/joy/CircularProgress'
+import GoogleLoginButton from '@/components/GoogleLoginButton'
 import { apiCall } from '@/utils/api'
 
 export default function LoginBtn({ inviteToken }) {
@@ -47,19 +47,9 @@ export default function LoginBtn({ inviteToken }) {
 
     return (
         <div className="flex flex-col items-center gap-2">
-            <GoogleLogin
+            <GoogleLoginButton
                 onSuccess={handleSuccess}
                 onError={() => setError('Google login failed. Please try again.')}
-                useOneTap
-                use_fedcm_for_prompt
-                use_fedcm_for_button
-                itp_support
-                auto_select={false}
-                cancel_on_tap_outside={false}
-                theme="outline"
-                shape="pill"
-                size="large"
-                text="signin_with"
             />
             {error && <p className="text-red-500 text-sm mt-1">{error}</p>}
         </div>

--- a/src/app/invite/[token]/page.jsx
+++ b/src/app/invite/[token]/page.jsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import { GoogleLogin } from '@react-oauth/google';
+import GoogleLoginButton from '@/components/GoogleLoginButton';
 import { validateToken, acceptInvite, rejectInvite } from './actions';
 import { apiCall } from '@/utils/api';
 
@@ -150,18 +150,9 @@ export default function InvitePage() {
           {signingIn ? (
             <p style={styles.subtitle}>Signing you in…</p>
           ) : (
-            <GoogleLogin
+            <GoogleLoginButton
               onSuccess={handleGoogleLogin}
               onError={() => setError('Google login failed')}
-              useOneTap
-              use_fedcm_for_prompt
-              use_fedcm_for_button
-              itp_support
-              auto_select={false}
-              cancel_on_tap_outside={false}
-              theme="outline"
-              shape="pill"
-              size="large"
             />
           )}
         </div>

--- a/src/components/GoogleLoginButton.jsx
+++ b/src/components/GoogleLoginButton.jsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { GoogleLogin } from '@react-oauth/google';
+
+// FedCM Button Flow needs Chrome 125+ desktop / 128+ Android.
+// Chrome 117–127 has the FedCM API but not button mode; passing
+// use_fedcm_for_button there prevents the button from rendering at all.
+function fedcmButtonSupported() {
+    if (typeof window === 'undefined' || !('IdentityCredential' in window)) return false;
+    const match = navigator.userAgent.match(/Chrome\/(\d+)/);
+    if (!match) return false;
+    const version = Number(match[1]);
+    return /Android/.test(navigator.userAgent) ? version >= 128 : version >= 125;
+}
+
+export default function GoogleLoginButton({ onSuccess, onError }) {
+    return (
+        <GoogleLogin
+            onSuccess={onSuccess}
+            onError={onError}
+            useOneTap
+            use_fedcm_for_prompt
+            {...(fedcmButtonSupported() ? { use_fedcm_for_button: true } : {})}
+            itp_support
+            auto_select={false}
+            cancel_on_tap_outside={false}
+            theme="outline"
+            shape="pill"
+            size="large"
+            text="signin_with"
+        />
+    );
+}


### PR DESCRIPTION
…s on older Chrome

use_fedcm_for_button needs Chrome 125+ desktop / 128+ Android. On Chrome 117-127 the FedCM API exists but button mode does not, and GIS fails in a way that leaves the Sign in with Google button unrendered. Extract a shared GoogleLoginButton that only passes use_fedcm_for_button when the browser actually supports it; older browsers fall back to the classic popup flow.


Claude-Session: https://claude.ai/code/session_01E72ckaqNSBnyM4AnZssBF8

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sambhusankar/RoomGrub/pull/58?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google sign-in button compatibility across supported Chrome browsers, including Android.
  * Prevented the sign-in button from failing to render on unsupported browser versions.
* **Improvements**
  * Standardized the Google sign-in experience on login and invitation pages.
  * Preserved existing success and error handling for Google authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->