### PR TITLE
Splits maintenance message + disable participant picker

### DIFF
--- a/src/app/[room_id]/addgroccery/_components/AddGroccery.jsx
+++ b/src/app/[room_id]/addgroccery/_components/AddGroccery.jsx
@@ -224,13 +224,13 @@ export default function AddGrocery({ userRole }) {
     const participantSlot = roomMembers.length > 0 && (
         <div className="relative">
             <button
-                onClick={() => setShowParticipantPicker(p => !p)}
-                className="flex items-center gap-1.5 text-sm text-purple-600 bg-purple-50 border border-purple-200 rounded-full px-3 py-1.5 active:bg-purple-100 select-none font-medium"
+                disabled
+                title="Participant selection is temporarily disabled"
+                className="flex items-center gap-1.5 text-sm text-purple-300 bg-purple-50 border border-purple-100 rounded-full px-3 py-1.5 select-none font-medium cursor-not-allowed opacity-60"
             >
-                <span>{participantIds.length === roomMembers.length ? 'Everyone' : `${participantIds.length} people`}</span>
-                <span className="text-purple-400 text-xs">▾</span>
+                <span>Everyone</span>
             </button>
-            {showParticipantPicker && (
+            {false && showParticipantPicker && (
                 <div className="absolute bottom-full mb-2 left-0 bg-white rounded-2xl shadow-xl border border-purple-100 py-2 min-w-[200px] z-10">
                     {roomMembers.map(member => (
                         <button

--- a/src/app/[room_id]/splits/page.jsx
+++ b/src/app/[room_id]/splits/page.jsx
@@ -1,22 +1,15 @@
-import dynamic from 'next/dynamic';
-import { auth, getUserRoomForRoom } from '@/auth';
-import { getSplitsData } from './actions';
-
-const SplitsDashboard = dynamic(() => import('./_components/SplitsDashboard'));
-
-export default async function SplitsPage({ params }) {
-    const session = await auth();
-    const { room_id } = await params;
-    const { data: membership } = await getUserRoomForRoom(session.user.email, room_id);
-    const { expenses, members, settlements } = await getSplitsData(room_id);
-
+export default async function SplitsPage() {
     return (
-        <SplitsDashboard
-            expenses={expenses}
-            members={members}
-            settlements={settlements}
-            roomId={room_id}
-            userRole={membership?.role ?? null}
-        />
+        <div
+            className="flex flex-col items-center justify-center text-center px-6 gap-3"
+            style={{ minHeight: 'calc(100dvh - 120px)' }}
+        >
+            <p className="text-purple-500 text-xs font-semibold tracking-widest uppercase">Splits</p>
+            <p className="text-2xl">🛠️</p>
+            <p className="text-lg font-semibold text-gray-800">Under maintenance</p>
+            <p className="text-sm text-gray-500 max-w-xs">
+                Sorry, splits summary is temporarily unavailable while we fix an issue. Back soon!
+            </p>
+        </div>
     );
 }

--- a/test/components/AddGroccery.test.js
+++ b/test/components/AddGroccery.test.js
@@ -112,7 +112,8 @@ describe('AddGrocery - participant picker', () => {
     );
   });
 
-  it('allows deselecting a non-payer participant and sends the reduced list', async () => {
+  // Participant picker is temporarily disabled; these interaction tests are skipped until it's re-enabled.
+  it.skip('allows deselecting a non-payer participant and sends the reduced list', async () => {
     addExpense.mockResolvedValue({ success: true });
     const user = userEvent.setup();
 
@@ -133,7 +134,7 @@ describe('AddGrocery - participant picker', () => {
     );
   });
 
-  it('does not allow deselecting the payer from the participant list', async () => {
+  it.skip('does not allow deselecting the payer from the participant list', async () => {
     addExpense.mockResolvedValue({ success: true });
     const user = userEvent.setup();
 
@@ -157,7 +158,7 @@ describe('AddGrocery - participant picker', () => {
     );
   });
 
-  it('never lets the participant list drop to zero since the payer is always locked in', async () => {
+  it.skip('never lets the participant list drop to zero since the payer is always locked in', async () => {
     addExpense.mockResolvedValue({ success: true });
     const user = userEvent.setup();
 


### PR DESCRIPTION
## Summary
- Splits page now shows a "under maintenance, sorry, back soon" message instead of the splits dashboard/summary
- Add Groccery participant picker button is disabled; expenses always default to all room members as participants

## Test plan
- [ ] Visit /[room_id]/splits and confirm maintenance message shows
- [ ] Visit /[room_id]/addgroccery and confirm participant button shows "Everyone" and is not clickable
- [ ] Confirm adding an expense still works and includes all members

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRTzS36aETGBmiKYoKBTgj

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sambhusankar/RoomGrub/pull/61?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Temporarily disabled participant selection when adding groceries, with an explanatory tooltip.
* **Updates**
  * The splits page now displays an “Under Maintenance” message instead of the splits dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->