### PR TITLE
Gate use_fedcm_for_prompt by FedCM support

### DIFF
--- a/src/components/GoogleLoginButton.jsx
+++ b/src/components/GoogleLoginButton.jsx
@@ -2,11 +2,18 @@
 
 import { GoogleLogin } from '@react-oauth/google';
 
+// initialize() and renderButton() run in the same synchronous GIS call, so any
+// unsupported FedCM flag passed to initialize() can prevent the button from
+// rendering at all, not just break the flag's own feature.
+function fedcmSupported() {
+    return typeof window !== 'undefined' && 'IdentityCredential' in window;
+}
+
 // FedCM Button Flow needs Chrome 125+ desktop / 128+ Android.
 // Chrome 117–127 has the FedCM API but not button mode; passing
 // use_fedcm_for_button there prevents the button from rendering at all.
 function fedcmButtonSupported() {
-    if (typeof window === 'undefined' || !('IdentityCredential' in window)) return false;
+    if (!fedcmSupported()) return false;
     const match = navigator.userAgent.match(/Chrome\/(\d+)/);
     if (!match) return false;
     const version = Number(match[1]);
@@ -19,7 +26,7 @@ export default function GoogleLoginButton({ onSuccess, onError }) {
             onSuccess={onSuccess}
             onError={onError}
             useOneTap
-            use_fedcm_for_prompt
+            {...(fedcmSupported() ? { use_fedcm_for_prompt: true } : {})}
             {...(fedcmButtonSupported() ? { use_fedcm_for_button: true } : {})}
             itp_support
             auto_select={false}


### PR DESCRIPTION
## Summary
- `initialize()` and `renderButton()` run in the same synchronous GIS call, so passing an unsupported FedCM flag to `initialize()` can prevent the login button from rendering at all.
- `use_fedcm_for_button` was already gated behind a Chrome-version check, but `use_fedcm_for_prompt` was always sent unconditionally — breaking the button on any browser lacking the FedCM/Credential Management API entirely.
- Extracted the shared `fedcmSupported()` check and gate `use_fedcm_for_prompt` behind it, independent of the button-mode version gate.

## Test plan
- [ ] Verify Google login button renders on current Chrome (FedCM + button mode supported)
- [ ] Verify Google login button renders on Chrome 117-127 (FedCM without button mode)
- [ ] Verify Google login button renders on a browser without FedCM support at all (older Chrome, or emulate via DevTools UA override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WyFfJq34DRr1oKk5h5VAy

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sambhusankar/RoomGrub/pull/64?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google sign-in compatibility by enabling FedCM prompting only in environments that support it.
  * Prevented potential sign-in issues in environments without the required browser APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->