### PR TITLE
Room dashboard cleanup and settings improvements

### DIFF
--- a/src/app/[room_id]/_components/RoomDashboardPage.jsx
+++ b/src/app/[room_id]/_components/RoomDashboardPage.jsx
@@ -1,13 +1,11 @@
 import Box from '@mui/joy/Box';
 import WelCome from './WelCome';
-import LazyNotificationPrompt from './LazyNotificationPrompt';
 import HomeDashboard from './HomeDashboard';
 
 export default function RoomDashboardPage({ firstName, totalRoomStats, memberStats }) {
   return (
     <Box sx={{ px: 2, py: 1 }}>
       <WelCome firstName={firstName} />
-      <LazyNotificationPrompt />
       {totalRoomStats && (
         <HomeDashboard totalRoomStats={totalRoomStats} memberStats={memberStats} />
       )}

--- a/src/app/[room_id]/actions.js
+++ b/src/app/[room_id]/actions.js
@@ -28,7 +28,10 @@ export async function fetchRoomDashboard(roomId) {
         const session = await auth();
         if (!session) return { totalRoomStats: null, memberStats: [] };
 
-        const data = await backendJson(`/api/v1/rooms/${roomId}/dashboard`);
+        const [data, summary] = await Promise.all([
+            backendJson(`/api/v1/rooms/${roomId}/dashboard`),
+            fetchHomeSummary(roomId),
+        ]);
         const members = data.members || [];
 
         const memberStats = members.map(m => ({
@@ -44,7 +47,6 @@ export async function fetchRoomDashboard(roomId) {
             status: (m.pending_amount ?? 0) > 0 ? 'pending' : 'settled',
         }));
 
-        const summary = await fetchHomeSummary(roomId);
         const totalRoomStats = {
             totalPurchases: summary.totalPurchases,
             pendingPayments: summary.pendingAmount,

--- a/src/app/[room_id]/actions.js
+++ b/src/app/[room_id]/actions.js
@@ -44,13 +44,11 @@ export async function fetchRoomDashboard(roomId) {
             status: (m.pending_amount ?? 0) > 0 ? 'pending' : 'settled',
         }));
 
-        const totalRoomStats = memberStats.reduce(
-            (acc, s) => ({
-                totalPurchases: acc.totalPurchases + s.totalPurchases,
-                pendingPayments: acc.pendingPayments + s.pendingAmount,
-            }),
-            { totalPurchases: 0, pendingPayments: 0 }
-        );
+        const summary = await fetchHomeSummary(roomId);
+        const totalRoomStats = {
+            totalPurchases: summary.totalPurchases,
+            pendingPayments: summary.pendingAmount,
+        };
 
         return { totalRoomStats, memberStats };
     } catch {

--- a/src/app/[room_id]/settings/_components/DangerZone.jsx
+++ b/src/app/[room_id]/settings/_components/DangerZone.jsx
@@ -5,7 +5,7 @@ import { Box, Typography, Button, Alert } from '@mui/joy';
 import { useRouter } from 'next/navigation';
 import useUserRole from '@/hooks/useUserRole';
 import { deleteRoom } from '../actions';
-import { exitRoom } from '../../members/actions';
+import { exitRoom } from '@/app/[room_id]/members/actions';
 
 export default function DangerZone({ roomId }) {
     const router = useRouter();

--- a/src/app/[room_id]/settings/_components/DangerZone.jsx
+++ b/src/app/[room_id]/settings/_components/DangerZone.jsx
@@ -5,15 +5,17 @@ import { Box, Typography, Button, Alert } from '@mui/joy';
 import { useRouter } from 'next/navigation';
 import useUserRole from '@/hooks/useUserRole';
 import { deleteRoom } from '../actions';
+import { exitRoom } from '../../members/actions';
 
 export default function DangerZone({ roomId }) {
     const router = useRouter();
     const { role, loadings } = useUserRole(roomId);
     const [deleting, setDeleting] = useState(false);
+    const [exiting, setExiting] = useState(false);
     const [error, setError] = useState(null);
     const [pendingExists, setPendingExists] = useState(false);
 
-    if (loadings || role !== 'Admin') return null;
+    if (loadings) return null;
 
     async function handleDeleteRoom() {
         if (!confirm('Are you absolutely sure? This will permanently delete the room and all its data. This action cannot be undone.')) return;
@@ -37,6 +39,72 @@ export default function DangerZone({ roomId }) {
         }
     }
 
+    async function handleExitRoom() {
+        if (!confirm('Are you sure you want to exit this room? You will need to join a new room.')) return;
+
+        setExiting(true);
+        setError(null);
+
+        try {
+            const result = await exitRoom(roomId);
+            if (result.success) {
+                router.push('/rooms');
+            } else {
+                setError(result.error);
+            }
+        } catch (err) {
+            setError('Something went wrong. Please try again.');
+        } finally {
+            setExiting(false);
+        }
+    }
+
+    if (role === 'Admin') {
+        return (
+            <Box
+                sx={{
+                    border: '1px solid',
+                    borderColor: 'danger.300',
+                    borderRadius: 'md',
+                    p: 3,
+                }}
+            >
+                <Typography level="title-lg" color="danger" sx={{ mb: 1 }}>
+                    Danger Zone
+                </Typography>
+                <Typography level="body-sm" sx={{ mb: 2, color: 'text.secondary' }}>
+                    Permanently delete this room and all its data. This action cannot be undone.
+                </Typography>
+
+                {error && (
+                    <Alert color="danger" sx={{ mb: 2 }}>
+                        {error}
+                        {pendingExists && (
+                            <Button
+                                variant="plain"
+                                color="danger"
+                                size="sm"
+                                onClick={() => router.push(`/${roomId}/splits`)}
+                                sx={{ ml: 1, p: 0, minHeight: 'unset', textDecoration: 'underline' }}
+                            >
+                                Go to Splits
+                            </Button>
+                        )}
+                    </Alert>
+                )}
+
+                <Button
+                    variant="outlined"
+                    color="danger"
+                    loading={deleting}
+                    onClick={handleDeleteRoom}
+                >
+                    Delete Room
+                </Button>
+            </Box>
+        );
+    }
+
     return (
         <Box
             sx={{
@@ -50,33 +118,22 @@ export default function DangerZone({ roomId }) {
                 Danger Zone
             </Typography>
             <Typography level="body-sm" sx={{ mb: 2, color: 'text.secondary' }}>
-                Permanently delete this room and all its data. This action cannot be undone.
+                Exit this room. You will need to join a new room to continue using RoomGrub.
             </Typography>
 
             {error && (
                 <Alert color="danger" sx={{ mb: 2 }}>
                     {error}
-                    {pendingExists && (
-                        <Button
-                            variant="plain"
-                            color="danger"
-                            size="sm"
-                            onClick={() => router.push(`/${roomId}/splits`)}
-                            sx={{ ml: 1, p: 0, minHeight: 'unset', textDecoration: 'underline' }}
-                        >
-                            Go to Splits
-                        </Button>
-                    )}
                 </Alert>
             )}
 
             <Button
                 variant="outlined"
                 color="danger"
-                loading={deleting}
-                onClick={handleDeleteRoom}
+                loading={exiting}
+                onClick={handleExitRoom}
             >
-                Delete Room
+                Exit Room
             </Button>
         </Box>
     );

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -3,16 +3,8 @@ import { useState, useRef, useEffect } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import Image from 'next/image';
 import { googleLogout } from '@react-oauth/google';
-import useUserRole from '@/hooks/useUserRole';
-import { exitRoom } from '@/app/[room_id]/members/actions';
 
 const LogoutIcon = () => (
-  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
-  </svg>
-);
-
-const ExitRoomIcon = () => (
   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
   </svg>
@@ -30,7 +22,6 @@ export default function NavBar({ user, signOut }) {
   const router = useRouter();
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef(null);
-  const { role } = useUserRole(room_id);
 
   useEffect(() => {
     const handleClickOutside = (e) => {
@@ -46,17 +37,6 @@ export default function NavBar({ user, signOut }) {
     setMenuOpen(false);
     googleLogout();
     signOut();
-  }
-
-  async function handleExitRoom() {
-    if (!confirm('Are you sure you want to exit this room? You will need to join a new room.')) return;
-    setMenuOpen(false);
-    const result = await exitRoom(room_id);
-    if (result.success) {
-      router.push('/rooms');
-    } else {
-      alert(`Error: ${result.error}`);
-    }
   }
 
   if (!user) return null;
@@ -119,14 +99,6 @@ export default function NavBar({ user, signOut }) {
               className="w-full text-left px-4 py-2 text-sm text-foreground hover:bg-brand-light flex items-center gap-2"
             >
               <SettingsIcon /> Settings
-            </button>
-          )}
-          {room_id && role && role !== 'Admin' && (
-            <button
-              onClick={handleExitRoom}
-              className="w-full text-left px-4 py-2 text-sm text-red-600 hover:bg-red-50 flex items-center gap-2"
-            >
-              <ExitRoomIcon /> Exit Room
             </button>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Fetch room total spent and pending amount from the `room_summary` endpoint instead of computing client-side
- Move exit room action from NavBar into the Settings page's Danger Zone
- Remove unused notification popup lazy loader from the dashboard page
- Gate `use_fedcm_for_prompt` by FedCM support to prevent the Google login button from vanishing

## Test plan
- [ ] Verify room dashboard displays correct total spent/pending amounts
- [ ] Verify exit room works from Settings > Danger Zone
- [ ] Verify Google login button renders on browsers without FedCM support

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PczpnEcpRM5PYTTSGM5XxF

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/sambhusankar/RoomGrub/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Exit Room” option to room settings for non-admin members, including confirmation, progress feedback, error handling, and redirect behavior.
  * Admins continue to have access to room deletion controls.

* **Bug Fixes**
  * Improved room dashboard totals by using the room-level summary for more accurate statistics.
  * Removed the notification prompt from the room dashboard.
  * Removed the duplicate room-exit option from the navigation menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->